### PR TITLE
fix: small error in `isOutOfStock` logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,13 +80,7 @@ async function lookup(store: Store) {
  */
 function isOutOfStock(domText: string, oosLabels: string[]) {
 	const domTextLowerCase = domText.toLowerCase();
-	for (const oosLabel of oosLabels) {
-		if (domTextLowerCase.includes(oosLabel.toLowerCase())) {
-			return true;
-		}
-	}
-
-	return false;
+	return oosLabels.some(label => domTextLowerCase.includes(label));
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,12 +80,12 @@ async function lookup(store: Store) {
  */
 function isOutOfStock(domText: string, oosLabels: string[]) {
 	const domTextLowerCase = domText.toLowerCase();
-	let result = false;
 	for (const oosLabel of oosLabels) {
-		result = domTextLowerCase.includes(oosLabel.toLowerCase());
+		if (domTextLowerCase.includes(oosLabel.toLowerCase())) {
+			return true;
+		}
 	}
-
-	return result;
+	return false;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ function isOutOfStock(domText: string, oosLabels: string[]) {
 			return true;
 		}
 	}
+
 	return false;
 }
 


### PR DESCRIPTION
### Description

While looking into adding some of the other bestbuy AIBs, I noticed that the loop in `isOutOfStock` will always return the check that coincides with the last value of `Store::oosLabels`. This does not align with the logic in the documentation:  

```Checks if DOM has any out-of-stock related text.```

This PR addresses this issue.

There are many different ways to do this, if you have a cleaner idea in mind, feel free to suggest one. I come from a mostly Java background so I'm unsure if node has a cleaner way to do this.
