### PR TITLE
feat: more Best Buy AIBs

### DIFF
--- a/src/store/bestbuy.ts
+++ b/src/store/bestbuy.ts
@@ -4,16 +4,47 @@ export const BestBuy: Store = {
 	cartUrl: '',
 	links: [
 		{
-			brand: 'nvidia',
-			model: 'founder edition',
-			url: 'https://www.bestbuy.com/site/nvidia-geforce-rtx-3080-10gb-gddr6x-pci-express-4-0-graphics-card-titanium-and-black/6429440.p?skuId=6429440',
-			oosLabels: ['sold out']
+			brand: 'asus',
+			model: 'rog strix',
+			url: 'https://www.bestbuy.com/site/asus-geforce-rtx-3080-10gb-gddr6x-pci-express-4-0-strix-graphics-card-black/6432445.p?skuId=6432445',
+			oosLabels: ['sold out', 'coming soon']
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 black',
+			url: 'https://www.bestbuy.com/site/evga-geforce-rtx-3080-10gb-gddr6x-pci-express-4-0-graphics-card/6432399.p?skuId=6432399',
+			oosLabels: ['sold out', 'coming soon']
+		},		
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			url: 'https://www.bestbuy.com/site/asus-geforce-rtx-3080-10gb-gddr6x-pci-express-4-0-strix-graphics-card-black/6432445.p?skuId=6432445',
+			oosLabels: ['sold out', 'coming soon']
 		},
 		{
 			brand: 'gigabyte',
 			model: 'black',
 			url: 'https://www.bestbuy.com/site/gigabyte-geforce-rtx-3080-10g-gddr6x-pci-express-4-0-graphics-card-black/6430620.p?acampID=0&cmp=RMX&loc=Hatch&ref=198&skuId=6430620',
-			oosLabels: ['sold out']
+			oosLabels: ['sold out', 'coming soon']
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle',
+			url: 'https://www.bestbuy.com/site/gigabyte-geforce-rtx-3080-10g-gddr6x-pci-express-4-0-graphics-card-black/6430621.p?skuId=6430621',
+			oosLabels: ['sold out', 'coming soon']
+		},
+				
+		{
+			brand: 'msi',
+			model: 'ventus 3x',
+			url: 'https://www.bestbuy.com/site/msi-geforce-rtx-3080-ventus-3x-10g-oc-bv-gddr6x-pci-express-4-0-graphic-card-black-silver/6430175.p?skuId=6430175',
+			oosLabels: ['sold out', 'coming soon']
+		},
+		{
+			brand: 'nvidia',
+			model: 'founder edition',
+			url: 'https://www.bestbuy.com/site/nvidia-geforce-rtx-3080-10gb-gddr6x-pci-express-4-0-graphics-card-titanium-and-black/6429440.p?skuId=6429440',
+			oosLabels: ['sold out', 'coming soon']
 		}
 	],
 	name: 'bestbuy'

--- a/src/store/bestbuy.ts
+++ b/src/store/bestbuy.ts
@@ -14,7 +14,7 @@ export const BestBuy: Store = {
 			model: 'xc3 black',
 			url: 'https://www.bestbuy.com/site/evga-geforce-rtx-3080-10gb-gddr6x-pci-express-4-0-graphics-card/6432399.p?skuId=6432399',
 			oosLabels: ['sold out', 'coming soon']
-		},		
+		},
 		{
 			brand: 'evga',
 			model: 'xc3 ultra',
@@ -33,7 +33,7 @@ export const BestBuy: Store = {
 			url: 'https://www.bestbuy.com/site/gigabyte-geforce-rtx-3080-10g-gddr6x-pci-express-4-0-graphics-card-black/6430621.p?skuId=6430621',
 			oosLabels: ['sold out', 'coming soon']
 		},
-				
+
 		{
 			brand: 'msi',
 			model: 'ventus 3x',


### PR DESCRIPTION
### Description

Update bestbuy.ts to include the remaining AIBs Best Buy currently offers.

This includes a change to the `oosLabels` for Best Buy links to include "Coming Soon". The pages we're sporadically changing between sold out + coming soon on occasion on the 3080's launch day. It's stood at Sold Out since, but just in case...
