### PR TITLE
Update nvidia.ts

### DIFF
--- a/src/store/nvidia.ts
+++ b/src/store/nvidia.ts
@@ -1,7 +1,7 @@
 import {Store} from './store';
 
 export const Nvidia: Store = {
-	cartUrl: '',
+	cartUrl: 'https://www.nvidia.com/en-us/shop/geforce/?page=1&limit=9&locale=en-us&gpu=RTX%203080&gpu_filter=RTX%203090~1,RTX%203080~7,RTX%203070~1,TITAN%20RTX~1,RTX%202080%20Ti~2,RTX%202080%20SUPER~16,RTX%202080~5,RTX%202070%20SUPER~26,RTX%202070~15,RTX%202060%20SUPER~7,RTX%202060~36,GTX%201660%20Ti~29,GTX%201660%20SUPER~4,GTX%201660~11,GTX%201650%20Ti~6,GTX%201650%20SUPER~8,GTX%201650~34',
 	links: [
 		{
 			brand: 'nvidia',


### PR DESCRIPTION
Currently if stock is detected via Digital River's API the bot would open the API result page, which doesn't really help purchase a card.  I added the nvidia store page as the cartUrl as a temporary workaround until an automatic add to cart function is implemented

<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
