### PR TITLE
perf: browser abstraction (#68)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,18 +3,22 @@ import {Stores} from './store/model';
 import {Logger} from './logger';
 import {sendNotification} from './notification';
 import {lookup} from './store';
+import puppeteer from 'puppeteer';
 
 /**
  * Starts the bot.
  */
 async function main() {
 	const results = [];
+	const browser = await puppeteer.launch();
+
 	for (const store of Stores) {
 		Logger.debug(store.links);
-		results.push(lookup(store));
+		results.push(lookup(browser, store));
 	}
 
 	await Promise.all(results);
+	await browser.close();
 
 	Logger.info('↗ trying stores again');
 	setTimeout(main, Config.rateLimitTimeout);

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -24,16 +24,16 @@ function filterBrand(brand: string) {
  * a `Store`. It's important that we ignore `no-await-in-loop` here
  * because we don't want to get rate limited within the same store.
  *
+ * @param browser Current browser in use.
  * @param store Vendor of graphics cards.
  */
-export async function lookup(store: Store) {
+export async function lookup(browser: puppeteer.Browser, store: Store) {
 /* eslint-disable no-await-in-loop */
 	for (const link of store.links) {
 		if (!filterBrand(link.brand)) {
 			continue;
 		}
 
-		const browser = await puppeteer.launch();
 		const page = await browser.newPage();
 		page.setDefaultNavigationTimeout(Config.page.navigationTimeout);
 		await page.setUserAgent(Config.page.userAgent);
@@ -48,7 +48,7 @@ export async function lookup(store: Store) {
 			await page.goto(link.url, {waitUntil: 'networkidle0'});
 		} catch {
 			Logger.error(`✖ [${store.name}] ${graphicsCard} skipping; timed out`);
-			await browser.close();
+			await page.close();
 			continue;
 		}
 
@@ -79,7 +79,7 @@ export async function lookup(store: Store) {
 			sendNotification(givenUrl);
 		}
 
-		await browser.close();
+		await page.close();
 	}
 /* eslint-enable no-await-in-loop */
 }


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Closes #68 

Improves performance by keeping the browser open once and closing when the program ends, rather than opening a browser and closing it every store.
