### PR TITLE
refactor: move `cartUrl` from `Store` to `Link`

### DIFF
--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -70,7 +70,7 @@ export async function lookup(browser: puppeteer.Browser, store: Store) {
 				await page.screenshot({path: `success-${Date.now()}.png`});
 			}
 
-			const givenUrl = store.cartUrl ? store.cartUrl : link.url;
+			const givenUrl = link.cartUrl ? link.cartUrl : link.url;
 
 			if (Config.openBrowser === 'true') {
 				await open(givenUrl);

--- a/src/store/model/bestbuy.ts
+++ b/src/store/model/bestbuy.ts
@@ -3,42 +3,49 @@ import {Store} from './store';
 export const BestBuy: Store = {
 	links: [
 		{
+			cartUrl: 'https://api.bestbuy.com/click/-/6432445/cart',
 			brand: 'asus',
 			model: 'rog strix',
 			url: 'https://www.bestbuy.com/site/asus-geforce-rtx-3080-10gb-gddr6x-pci-express-4-0-strix-graphics-card-black/6432445.p?skuId=6432445',
 			oosLabels: ['sold out', 'coming soon']
 		},
 		{
+			cartUrl: 'https://api.bestbuy.com/click/-/6432399/cart',
 			brand: 'evga',
 			model: 'xc3 black',
 			url: 'https://www.bestbuy.com/site/evga-geforce-rtx-3080-10gb-gddr6x-pci-express-4-0-graphics-card/6432399.p?skuId=6432399',
 			oosLabels: ['sold out', 'coming soon']
 		},
 		{
+			cartUrl: 'https://api.bestbuy.com/click/-/6432400/cart',
 			brand: 'evga',
 			model: 'xc3 ultra',
 			url: 'https://www.bestbuy.com/site/evga-geforce-rtx-3080-10gb-gddr6x-pci-express-4-0-graphics-card/6432400.p?skuId=6432400',
 			oosLabels: ['sold out', 'coming soon']
 		},
 		{
+			cartUrl: 'https://api.bestbuy.com/click/-/6430620/cart',
 			brand: 'gigabyte',
 			model: 'black',
 			url: 'https://www.bestbuy.com/site/gigabyte-geforce-rtx-3080-10g-gddr6x-pci-express-4-0-graphics-card-black/6430620.p?acampID=0&cmp=RMX&loc=Hatch&ref=198&skuId=6430620',
 			oosLabels: ['sold out', 'coming soon']
 		},
 		{
+			cartUrl: 'https://api.bestbuy.com/click/-/6430621/cart',
 			brand: 'gigabyte',
 			model: 'eagle',
 			url: 'https://www.bestbuy.com/site/gigabyte-geforce-rtx-3080-10g-gddr6x-pci-express-4-0-graphics-card-black/6430621.p?skuId=6430621',
 			oosLabels: ['sold out', 'coming soon']
 		},
 		{
+			cartUrl: 'https://api.bestbuy.com/click/-/6430175/cart',
 			brand: 'msi',
 			model: 'ventus 3x',
 			url: 'https://www.bestbuy.com/site/msi-geforce-rtx-3080-ventus-3x-10g-oc-bv-gddr6x-pci-express-4-0-graphic-card-black-silver/6430175.p?skuId=6430175',
 			oosLabels: ['sold out', 'coming soon']
 		},
 		{
+			cartUrl: 'https://api.bestbuy.com/click/-/6429440/cart',
 			brand: 'nvidia',
 			model: 'founder edition',
 			url: 'https://www.bestbuy.com/site/nvidia-geforce-rtx-3080-10gb-gddr6x-pci-express-4-0-graphics-card-titanium-and-black/6429440.p?skuId=6429440',

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -1,4 +1,5 @@
 interface Link {
+	cartUrl?: string;
 	brand: string;
 	model: string;
 	url: string;
@@ -7,7 +8,6 @@ interface Link {
 }
 
 export interface Store {
-	cartUrl?: string;
 	links: Link[];
 	name: string;
 }


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

As-is the bot only has the ability to have 1 `cartUrl` per site.  The problem is, if a site has multiple links (as almost all do now) you can only assign a single `cartUrl`.  With this change, individual `cartUrl` can be assigned to each link.  By moving the `cartUrl` into the `Links:` we can assign individual `cartUrl` addresses when a product is detected.  I found the add to cart URLs for Best Buy and used it as a proof of concept. 
<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing

Tested by changing 1 of the Best Buy links to https://www.google.com the bot detected available stock (as expected) but opened the Best Buy add to cart URL instead of the product page.  I also reverted the Best Buy product URL back to the proper URL to ensure it detected no stock as expected.
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

None
<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
