### PR TITLE
Fix #58 rare false positive on hitting rate limit

### DIFF
--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -44,8 +44,9 @@ export async function lookup(browser: puppeteer.Browser, store: Store) {
 
 		const graphicsCard = `${link.brand} ${link.model}`;
 
+		let response: puppeteer.Response | null;
 		try {
-			await page.goto(link.url, {waitUntil: 'networkidle0'});
+			response = await page.goto(link.url, {waitUntil: 'networkidle0'});
 		} catch {
 			Logger.error(`✖ [${store.name}] ${graphicsCard} skipping; timed out`);
 			await page.close();
@@ -61,6 +62,8 @@ export async function lookup(browser: puppeteer.Browser, store: Store) {
 			Logger.info(`✖ [${store.name}] still out of stock: ${graphicsCard}`);
 		} else if (link.captchaLabels && includesLabels(textContent, link.captchaLabels)) {
 			Logger.warn(`✖ [${store.name}] CAPTCHA from: ${graphicsCard}`);
+		} else if (response && response.status() === 429){
+			Logger.warn(`✖ [${store.name}] Rate limit exceeded: ${graphicsCard}`)
 		} else {
 			Logger.info(`🚀🚀🚀 [${store.name}] ${graphicsCard} IN STOCK 🚀🚀🚀`);
 			Logger.info(link.url);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+	"sourceMap": true
   }
 }


### PR DESCRIPTION
### Description

Fixes #58 
The issue has been adressed previously, but not been fixed in it's entirety.
This PR fixes the issue by checking for a 429 HTTP response.

### Testing

I ran the script for about half an hour with only the default configuration enabled.
