### PR TITLE
feat: add delay on captcha to try and evade faster

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,8 @@ import adblockerPlugin from 'puppeteer-extra-plugin-adblocker';
 import {Config} from './config';
 import {Stores} from './store/model';
 import {Logger} from './logger';
-import {getSleepTime, tryLookupAndLoop} from './store';
+import {tryLookupAndLoop} from './store';
+import {getSleepTime} from './util';
 
 puppeteer.use(stealthPlugin());
 puppeteer.use(adblockerPlugin({blockTrackers: true}));

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -5,6 +5,7 @@ import open from 'open';
 import {Store} from './model';
 import {sendNotification} from '../notification';
 import {includesLabels} from './includes-labels';
+import {delay, getSleepTime} from '../util';
 
 /**
  * Returns true if the brand should be checked for stock
@@ -56,7 +57,8 @@ async function lookup(browser: Browser, store: Store) {
 		if (includesLabels(textContent, link.oosLabels)) {
 			Logger.info(`✖ [${store.name}] still out of stock: ${graphicsCard}`);
 		} else if (link.captchaLabels && includesLabels(textContent, link.captchaLabels)) {
-			Logger.warn(`✖ [${store.name}] CAPTCHA from: ${graphicsCard}`);
+			Logger.warn(`✖ [${store.name}] CAPTCHA from: ${graphicsCard}. Waiting for a bit with this store...`);
+			await delay(getSleepTime());
 		} else if (response && response.status() === 429) {
 			Logger.warn(`✖ [${store.name}] Rate limit exceeded: ${graphicsCard}`);
 		} else {
@@ -80,10 +82,6 @@ async function lookup(browser: Browser, store: Store) {
 		await page.close();
 	}
 /* eslint-enable no-await-in-loop */
-}
-
-export function getSleepTime() {
-	return Config.browser.minSleep + (Math.random() * (Config.browser.maxSleep - Config.browser.minSleep));
 }
 
 export async function tryLookupAndLoop(browser: Browser, store: Store) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,11 @@
+import {Config} from './config';
+
+export function getSleepTime() {
+	return Config.browser.minSleep + (Math.random() * (Config.browser.maxSleep - Config.browser.minSleep));
+}
+
+export async function delay(ms: number) {
+	return new Promise(resolve => {
+		setTimeout(resolve, ms);
+	});
+}


### PR DESCRIPTION
### Description

Adds a delay whenever we get a CAPTCHA. Seems to work well on newegg.
It also moves the sleep functions to a util.ts file

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
