### PR TITLE
fix: memory leak due to adblocker

### DIFF
--- a/src/adblocker.ts
+++ b/src/adblocker.ts
@@ -1,0 +1,11 @@
+import {Page} from 'puppeteer';
+import {PuppeteerExtraPluginAdblocker} from 'puppeteer-extra-plugin-adblocker';
+
+export const adBlocker = new PuppeteerExtraPluginAdblocker({
+	blockTrackers: true
+});
+
+export async function disableBlockerInPage(page: Page) {
+	const blockerObject = await adBlocker.getBlocker();
+	await blockerObject.disableBlockingInPage(page);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,14 @@
 import puppeteer from 'puppeteer-extra';
 import stealthPlugin from 'puppeteer-extra-plugin-stealth';
-import adblockerPlugin from 'puppeteer-extra-plugin-adblocker';
 import {Config} from './config';
 import {Stores} from './store/model';
 import {Logger} from './logger';
 import {tryLookupAndLoop} from './store';
 import {getSleepTime} from './util';
+import {adBlocker} from './adblocker';
 
 puppeteer.use(stealthPlugin());
-puppeteer.use(adblockerPlugin({blockTrackers: true}));
+puppeteer.use(adBlocker);
 
 /**
  * Starts the bot.

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -5,7 +5,7 @@ import open from 'open';
 import {Store} from './model';
 import {sendNotification} from '../notification';
 import {includesLabels} from './includes-labels';
-import {delay, getSleepTime} from '../util';
+import {closePage, delay, getSleepTime} from '../util';
 
 /**
  * Returns true if the brand should be checked for stock
@@ -62,7 +62,7 @@ async function lookup(browser: Browser, store: Store) {
 			response = await page.goto(link.url, {waitUntil: 'networkidle0'});
 		} catch {
 			Logger.error(`✖ [${store.name}] ${graphicsCard} skipping; timed out`);
-			await page.close();
+			await closePage(page);
 			continue;
 		}
 
@@ -96,7 +96,7 @@ async function lookup(browser: Browser, store: Store) {
 			sendNotification(givenUrl, link);
 		}
 
-		await page.close();
+		await closePage(page);
 	}
 	/* eslint-enable no-await-in-loop */
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,6 @@
+import {Page} from 'puppeteer';
 import {Config} from './config';
+import {disableBlockerInPage} from './adblocker';
 
 export function getSleepTime() {
 	return Config.browser.minSleep + (Math.random() * (Config.browser.maxSleep - Config.browser.minSleep));
@@ -8,4 +10,9 @@ export async function delay(ms: number) {
 	return new Promise(resolve => {
 		setTimeout(resolve, ms);
 	});
+}
+
+export async function closePage(page: Page) {
+	await disableBlockerInPage(page);
+	await page.close();
 }


### PR DESCRIPTION
### Description

Plugs a memory leak due to some architectural oversights in the adblocker plugin.
It must be detached manually from every page, or it will keep a stale reference alive and prevent it from being GC'd

### Testing

Heapdumps and checking via `htop` for memory allocations

