### PR TITLE
feat: temporarily pause requests if store has stock

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -3,6 +3,7 @@ DISCORD_WEB_HOOK="https://discordapp.com/api/webhooks/23123123123/5dfsdfh3h2j5hd
 EMAIL_USERNAME="youremail@gmail.com"
 EMAIL_PASSWORD="secretpassword"
 HEADLESS="true"
+IN_STOCK_WAIT_TIME="30"
 LOG_LEVEL="info"
 OPEN_BROWSER="true"
 PAGE_TIMEOUT="30000"

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Here is a list of variables that you can use to customize your newly copied `.en
 | `EMAIL_USERNAME` | Gmail address | E.g.: `jensen.robbed.us@gmail.com` |
 | `EMAIL_PASSWORD` | Gmail password | See below if you have MFA | 
 | `HEADLESS` | Puppeteer to run headless or not | Debugging related, default: `true` |
+| `IN_STOCK_WAIT_TIME` | Time to wait between requests to the same store if it has cards in stock | In seconds, default: `0` |
 | `LOG_LEVEL` | [Logging levels](https://github.com/winstonjs/winston#logging-levels) | Debugging related, default: `info` |
 | `OPEN_BROWSER` | Toggle for whether or not the browser should open when item is found | Default: `true` |
 | `PAGE_TIMEOUT` | Navigation Timeout in milliseconds | `0` for infinite, default: `30000` |

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,7 +56,8 @@ const page = {
 	width: 1920,
 	height: 1080,
 	navigationTimeout: Number(process.env.PAGE_TIMEOUT ?? 30000),
-	userAgent: process.env.USER_AGENT ?? 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36'
+	userAgent: process.env.USER_AGENT ?? 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36',
+	inStockWaitTime: Number(process.env.IN_STOCK_WAIT_TIME ?? 0)
 };
 
 const store = {

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -7,7 +7,7 @@ import {sendNotification} from '../notification';
 import {includesLabels} from './includes-labels';
 import {closePage, delay, getSleepTime} from '../util';
 
-let inStock: Record<string, boolean> = {};
+const inStock: Record<string, boolean> = {};
 
 /**
  * Returns true if the brand should be checked for stock
@@ -85,7 +85,9 @@ async function lookup(browser: Browser, store: Store) {
 			Logger.info(link.url);
 			if (Config.page.inStockWaitTime) {
 				inStock[store.name] = true;
-				setTimeout(() => { inStock[store.name] = false; }, 1000 * Config.page.inStockWaitTime);
+				setTimeout(() => {
+					inStock[store.name] = false;
+				}, 1000 * Config.page.inStockWaitTime);
 			}
 
 			if (Config.page.capture) {

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -7,6 +7,8 @@ import {sendNotification} from '../notification';
 import {includesLabels} from './includes-labels';
 import {closePage, delay, getSleepTime} from '../util';
 
+let inStock: Record<string, boolean> = {};
+
 /**
  * Returns true if the brand should be checked for stock
  *
@@ -81,6 +83,10 @@ async function lookup(browser: Browser, store: Store) {
 		} else {
 			Logger.info(`🚀🚀🚀 [${store.name}] ${graphicsCard} IN STOCK 🚀🚀🚀`);
 			Logger.info(link.url);
+			if (Config.page.inStockWaitTime) {
+				inStock[store.name] = true;
+				setTimeout(() => { inStock[store.name] = false; }, 1000 * Config.page.inStockWaitTime);
+			}
 
 			if (Config.page.capture) {
 				Logger.debug('ℹ saving screenshot');
@@ -105,7 +111,11 @@ async function lookup(browser: Browser, store: Store) {
 export async function tryLookupAndLoop(browser: Browser, store: Store) {
 	Logger.debug(`[${store.name}] Starting lookup...`);
 	try {
-		await lookup(browser, store);
+		if (Config.page.inStockWaitTime && inStock[store.name]) {
+			Logger.info(`[${store.name}] Has stock, waiting before trying to lookup again...`);
+		} else {
+			await lookup(browser, store);
+		}
 	} catch (error) {
 		Logger.error(error);
 	}


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Adds a new config option `IN_STOCK_WAIT_TIME` that controls the amount of time to wait between consecutive requests to the same store if the store has a card in stock. This is to reduce requests to the store during a time when the user is presumably scrambling to check out. Setting it to 0 (the default value) bypasses this feature entirely.

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

<!-- Feel free to include your Discord tag here and we'll consider making you a ringer! -->
<!-- Continuous improvements may also grant you contributor access. -->

### Testing

Tested with the in-stock debug cards.
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
