### PR TITLE
chore(store): evga oos label

### DIFF
--- a/src/store/model/evga.ts
+++ b/src/store/model/evga.ts
@@ -34,7 +34,7 @@ export const Evga: Store = {
 		}
 	],
 	labels: {
-		outOfStock: ['out of stock']
+		outOfStock: ['out of stock', 'error reaching the evga website']
 	},
 	name: 'evga'
 };


### PR DESCRIPTION
Updated labels to avoid false-positive when their site goes down.

![image](https://user-images.githubusercontent.com/799451/93826702-0ff62300-fc25-11ea-9539-c5be238af63c.png)
