### PR TITLE
feat(store): multiple inStock labels config

### DIFF
--- a/src/__test__/notification-test.ts
+++ b/src/__test__/notification-test.ts
@@ -11,10 +11,10 @@ const link: Link = {
 
 const store: Store = {
 	labels: {
-		inStock: {
-			containers: ['test:container'],
+		inStock: [{
+			container: 'test:container',
 			text: ['test:text']
-		}
+		}]
 	},
 	links: [link],
 	name: 'test:name'

--- a/src/__test__/notification-test.ts
+++ b/src/__test__/notification-test.ts
@@ -12,7 +12,7 @@ const link: Link = {
 const store: Store = {
 	labels: {
 		inStock: {
-			container: 'test:container',
+			containers: ['test:container'],
 			text: ['test:text']
 		}
 	},

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -1,5 +1,5 @@
 import {Browser, Page, Response} from 'puppeteer';
-import {Link, Store} from './model';
+import {Link, Element, Store} from './model';
 import {Logger, Print} from '../logger';
 import {closePage, delay, getSleepTime} from '../util';
 import {Config} from '../config';
@@ -92,8 +92,8 @@ async function lookupCard(browser: Browser, store: Store, page: Page, link: Link
 
 async function lookupCardInStock(store: Store, page: Page) {
 	/* eslint-disable no-await-in-loop */
-	for (const container of store.labels.inStock.containers) {
-		if (await lookupPageHasContent(page, container, store.labels.inStock.text)) {
+	for (const element of store.labels.inStock) {
+		if (await lookupPageHasContent(page, element)) {
 			return true;
 		}
 	}
@@ -118,7 +118,7 @@ async function lookupPageHasCaptcha(store: Store, page: Page) {
 	return false;
 }
 
-async function lookupPageHasContent(page: Page, container: string, text: string[]) {
+async function lookupPageHasContent(page: Page, element: Element) {
 	const handle = await page.$(container);
 
 	const visible = await page.evaluate(element => element && element.offsetWidth > 0 && element.offsetHeight > 0, handle);

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -1,5 +1,5 @@
 import {Browser, Page, Response} from 'puppeteer';
-import {Link, Element, Store} from './model';
+import {Element, Link, Store} from './model';
 import {Logger, Print} from '../logger';
 import {closePage, delay, getSleepTime} from '../util';
 import {Config} from '../config';
@@ -92,8 +92,8 @@ async function lookupCard(browser: Browser, store: Store, page: Page, link: Link
 
 async function lookupCardInStock(store: Store, page: Page) {
 	/* eslint-disable no-await-in-loop */
-	for (const element of store.labels.inStock) {
-		if (await lookupPageHasContent(page, element)) {
+	for (const search of store.labels.inStock) {
+		if (await lookupPageHasContent(page, search)) {
 			return true;
 		}
 	}
@@ -107,19 +107,15 @@ async function lookupPageHasCaptcha(store: Store, page: Page) {
 		return false;
 	}
 
-	/* eslint-disable no-await-in-loop */
-	for (const container of store.labels.captcha.containers) {
-		if (await lookupPageHasContent(page, container, store.labels.captcha.text)) {
-			return true;
-		}
+	if (await lookupPageHasContent(page, store.labels.captcha)) {
+		return true;
 	}
-	/* eslint-enable no-await-in-loop */
 
 	return false;
 }
 
-async function lookupPageHasContent(page: Page, element: Element) {
-	const handle = await page.$(container);
+async function lookupPageHasContent(page: Page, search: Element) {
+	const handle = await page.$(search.container);
 
 	const visible = await page.evaluate(element => element && element.offsetWidth > 0 && element.offsetHeight > 0, handle);
 	if (!visible) {
@@ -130,7 +126,7 @@ async function lookupPageHasContent(page: Page, element: Element) {
 
 	Logger.debug(content);
 
-	return includesLabels(content, text);
+	return includesLabels(content, search.text);
 }
 
 export async function tryLookupAndLoop(browser: Browser, store: Store) {

--- a/src/store/lookup.ts
+++ b/src/store/lookup.ts
@@ -93,7 +93,7 @@ async function lookupCard(browser: Browser, store: Store, page: Page, link: Link
 async function lookupCardInStock(store: Store, page: Page) {
 	/* eslint-disable no-await-in-loop */
 	for (const container of store.labels.inStock.containers) {
-		if (await lookupCardHasContent(page, container, store.labels.inStock.text)) {
+		if (await lookupPageHasContent(page, container, store.labels.inStock.text)) {
 			return true;
 		}
 	}
@@ -109,7 +109,7 @@ async function lookupPageHasCaptcha(store: Store, page: Page) {
 
 	/* eslint-disable no-await-in-loop */
 	for (const container of store.labels.captcha.containers) {
-		if (await lookupCardHasContent(page, container, store.labels.captcha.text)) {
+		if (await lookupPageHasContent(page, container, store.labels.captcha.text)) {
 			return true;
 		}
 	}
@@ -118,7 +118,7 @@ async function lookupPageHasCaptcha(store: Store, page: Page) {
 	return false;
 }
 
-async function lookupCardHasContent(page: Page, container: string, text: string[]) {
+async function lookupPageHasContent(page: Page, container: string, text: string[]) {
 	const handle = await page.$(container);
 
 	const visible = await page.evaluate(element => element && element.offsetWidth > 0 && element.offsetHeight > 0, handle);

--- a/src/store/model/adorama.ts
+++ b/src/store/model/adorama.ts
@@ -3,13 +3,13 @@ import {Store} from './store';
 export const Adorama: Store = {
 	labels: {
 		captcha: {
-			containers: ['body'],
+			container: 'body',
 			text: ['please verify you are a human']
 		},
-		inStock: {
-			containers: ['.buy-section.purchase'],
+		inStock: [{
+			container: '.buy-section.purchase',
 			text: ['add to cart']
-		}
+		}]
 	},
 	links: [
 		{

--- a/src/store/model/adorama.ts
+++ b/src/store/model/adorama.ts
@@ -3,11 +3,11 @@ import {Store} from './store';
 export const Adorama: Store = {
 	labels: {
 		captcha: {
-			container: 'body',
+			containers: ['body'],
 			text: ['please verify you are a human']
 		},
 		inStock: {
-			container: '.buy-section.purchase',
+			containers: ['.buy-section.purchase'],
 			text: ['add to cart']
 		}
 	},

--- a/src/store/model/amazon-ca.ts
+++ b/src/store/model/amazon-ca.ts
@@ -3,11 +3,11 @@ import {Store} from './store';
 export const AmazonCa: Store = {
 	labels: {
 		captcha: {
-			container: 'body',
+			containers: ['body'],
 			text: ['enter the characters you see below']
 		},
 		inStock: {
-			container: '#desktop_buybox',
+			containers: ['#desktop_buybox'],
 			text: ['add to cart']
 		}
 	},

--- a/src/store/model/amazon-ca.ts
+++ b/src/store/model/amazon-ca.ts
@@ -3,13 +3,13 @@ import {Store} from './store';
 export const AmazonCa: Store = {
 	labels: {
 		captcha: {
-			containers: ['body'],
+			container: 'body',
 			text: ['enter the characters you see below']
 		},
-		inStock: {
-			containers: ['#desktop_buybox'],
+		inStock: [{
+			container: '#desktop_buybox',
 			text: ['add to cart']
-		}
+		}]
 	},
 	links: [
 		{

--- a/src/store/model/amazon-de.ts
+++ b/src/store/model/amazon-de.ts
@@ -3,13 +3,13 @@ import {Store} from './store';
 export const AmazonDe: Store = {
 	labels: {
 		captcha: {
-			containers: ['body'],
+			container: 'body',
 			text: ['geben sie die unten angezeigten zeichen ein']
 		},
-		inStock: {
-			containers: ['#desktop_buybox'],
+		inStock: [{
+			container: '#desktop_buybox',
 			text: ['in den einkaufswagen']
-		}
+		}]
 	},
 	links: [
 		{

--- a/src/store/model/amazon-de.ts
+++ b/src/store/model/amazon-de.ts
@@ -3,11 +3,11 @@ import {Store} from './store';
 export const AmazonDe: Store = {
 	labels: {
 		captcha: {
-			container: 'body',
+			containers: ['body'],
 			text: ['geben sie die unten angezeigten zeichen ein']
 		},
 		inStock: {
-			container: '#desktop_buybox',
+			containers: ['#desktop_buybox'],
 			text: ['in den einkaufswagen']
 		}
 	},

--- a/src/store/model/amazon.ts
+++ b/src/store/model/amazon.ts
@@ -3,13 +3,13 @@ import {Store} from './store';
 export const Amazon: Store = {
 	labels: {
 		captcha: {
-			containers: ['body'],
+			container: 'body',
 			text: ['enter the characters you see below']
 		},
-		inStock: {
-			containers: ['#desktop_buybox'],
+		inStock: [{
+			container: '#desktop_buybox',
 			text: ['add to cart']
-		}
+		}]
 	},
 	links: [
 		{

--- a/src/store/model/amazon.ts
+++ b/src/store/model/amazon.ts
@@ -3,11 +3,11 @@ import {Store} from './store';
 export const Amazon: Store = {
 	labels: {
 		captcha: {
-			container: 'body',
+			containers: ['body'],
 			text: ['enter the characters you see below']
 		},
 		inStock: {
-			container: '#desktop_buybox',
+			containers: ['#desktop_buybox'],
 			text: ['add to cart']
 		}
 	},

--- a/src/store/model/asus.ts
+++ b/src/store/model/asus.ts
@@ -3,7 +3,7 @@ import {Store} from './store';
 export const Asus: Store = {
 	labels: {
 		inStock: {
-			container: '#item_add_cart',
+			containers: ['#item_add_cart'],
 			text: ['add to cart']
 		}
 	},

--- a/src/store/model/asus.ts
+++ b/src/store/model/asus.ts
@@ -2,10 +2,10 @@ import {Store} from './store';
 
 export const Asus: Store = {
 	labels: {
-		inStock: {
-			containers: ['#item_add_cart'],
+		inStock: [{
+			container: '#item_add_cart',
 			text: ['add to cart']
-		}
+		}]
 	},
 	links: [
 		{

--- a/src/store/model/bandh.ts
+++ b/src/store/model/bandh.ts
@@ -2,10 +2,10 @@ import {Store} from './store';
 
 export const BAndH: Store = {
 	labels: {
-		inStock: {
-			containers: ['div[data-selenium="addToCartSection"]'],
+		inStock: [{
+			container: 'div[data-selenium="addToCartSection"]',
 			text: ['add to cart']
-		}
+		}]
 	},
 	links: [
 		{

--- a/src/store/model/bandh.ts
+++ b/src/store/model/bandh.ts
@@ -3,7 +3,7 @@ import {Store} from './store';
 export const BAndH: Store = {
 	labels: {
 		inStock: {
-			container: 'div[data-selenium="addToCartSection"]',
+			containers: ['div[data-selenium="addToCartSection"]'],
 			text: ['add to cart']
 		}
 	},

--- a/src/store/model/bestbuy-ca.ts
+++ b/src/store/model/bestbuy-ca.ts
@@ -3,7 +3,7 @@ import {Store} from './store';
 export const BestBuyCa: Store = {
 	labels: {
 		inStock: {
-			container: '#root',
+			containers: ['#root'],
 			text: ['available online']
 		}
 	},

--- a/src/store/model/bestbuy-ca.ts
+++ b/src/store/model/bestbuy-ca.ts
@@ -2,10 +2,10 @@ import {Store} from './store';
 
 export const BestBuyCa: Store = {
 	labels: {
-		inStock: {
-			containers: ['#root'],
+		inStock: [{
+			container: '#root',
 			text: ['available online']
-		}
+		}]
 	},
 	links: [
 		{

--- a/src/store/model/bestbuy.ts
+++ b/src/store/model/bestbuy.ts
@@ -2,10 +2,10 @@ import {Store} from './store';
 
 export const BestBuy: Store = {
 	labels: {
-		inStock: {
-			containers: ['.v-m-bottom-g'],
+		inStock: [{
+			container: '.v-m-bottom-g',
 			text: ['add to cart']
-		}
+		}]
 	},
 	links: [
 		{

--- a/src/store/model/bestbuy.ts
+++ b/src/store/model/bestbuy.ts
@@ -3,7 +3,7 @@ import {Store} from './store';
 export const BestBuy: Store = {
 	labels: {
 		inStock: {
-			container: '.v-m-bottom-g',
+			containers: ['.v-m-bottom-g'],
 			text: ['add to cart']
 		}
 	},

--- a/src/store/model/evga-eu.ts
+++ b/src/store/model/evga-eu.ts
@@ -3,7 +3,7 @@ import {Store} from './store';
 export const EvgaEu: Store = {
 	labels: {
 		inStock: {
-			container: '.product-buy-specs',
+			containers: ['.product-buy-specs'],
 			text: ['add to cart']
 		}
 	},

--- a/src/store/model/evga-eu.ts
+++ b/src/store/model/evga-eu.ts
@@ -2,10 +2,10 @@ import {Store} from './store';
 
 export const EvgaEu: Store = {
 	labels: {
-		inStock: {
-			containers: ['.product-buy-specs'],
+		inStock: [{
+			container: '.product-buy-specs',
 			text: ['add to cart']
-		}
+		}]
 	},
 	links: [
 		{

--- a/src/store/model/evga.ts
+++ b/src/store/model/evga.ts
@@ -2,10 +2,10 @@ import {Store} from './store';
 
 export const Evga: Store = {
 	labels: {
-		inStock: {
-			containers: ['.product-buy-specs'],
+		inStock: [{
+			container: '.product-buy-specs',
 			text: ['add to cart']
-		}
+		}]
 	},
 	links: [
 		{

--- a/src/store/model/evga.ts
+++ b/src/store/model/evga.ts
@@ -3,7 +3,7 @@ import {Store} from './store';
 export const Evga: Store = {
 	labels: {
 		inStock: {
-			container: '.product-buy-specs',
+			containers: ['.product-buy-specs'],
 			text: ['add to cart']
 		}
 	},

--- a/src/store/model/microcenter.ts
+++ b/src/store/model/microcenter.ts
@@ -41,7 +41,7 @@ if (microCenterLocationToId.get(MicroCenterLocation) === undefined) {
 export const MicroCenter: Store = {
 	labels: {
 		inStock: {
-			container: '#cart-options',
+			containers: ['#cart-options'],
 			text: ['in stock']
 		}
 	},

--- a/src/store/model/microcenter.ts
+++ b/src/store/model/microcenter.ts
@@ -40,10 +40,10 @@ if (microCenterLocationToId.get(MicroCenterLocation) === undefined) {
 
 export const MicroCenter: Store = {
 	labels: {
-		inStock: {
-			containers: ['#cart-options'],
+		inStock: [{
+			container: '#cart-options',
 			text: ['in stock']
-		}
+		}]
 	},
 	links: [
 		{

--- a/src/store/model/newegg-ca.ts
+++ b/src/store/model/newegg-ca.ts
@@ -3,13 +3,13 @@ import {Store} from './store';
 export const NeweggCa: Store = {
 	labels: {
 		captcha: {
-			containers: ['body'],
+			container: 'body',
 			text: ['are you a human?']
 		},
-		inStock: {
-			containers: ['#landingpage-cart .btn-primary span'],
+		inStock: [{
+			container: '#landingpage-cart .btn-primary span',
 			text: ['add to cart']
-		}
+		}]
 	},
 	links: [
 		{

--- a/src/store/model/newegg-ca.ts
+++ b/src/store/model/newegg-ca.ts
@@ -3,11 +3,11 @@ import {Store} from './store';
 export const NeweggCa: Store = {
 	labels: {
 		captcha: {
-			container: 'body',
+			containers: ['body'],
 			text: ['are you a human?']
 		},
 		inStock: {
-			container: '#landingpage-cart .btn-primary span',
+			containers: ['#landingpage-cart .btn-primary span'],
 			text: ['add to cart']
 		}
 	},

--- a/src/store/model/newegg.ts
+++ b/src/store/model/newegg.ts
@@ -3,11 +3,11 @@ import {Store} from './store';
 export const Newegg: Store = {
 	labels: {
 		captcha: {
-			container: 'body',
+			containers: ['body'],
 			text: ['are you a human?']
 		},
 		inStock: {
-			container: '#landingpage-cart .btn-primary span',
+			containers: ['#landingpage-cart .btn-primary span'],
 			text: ['add to cart']
 		}
 	},

--- a/src/store/model/newegg.ts
+++ b/src/store/model/newegg.ts
@@ -3,13 +3,13 @@ import {Store} from './store';
 export const Newegg: Store = {
 	labels: {
 		captcha: {
-			containers: ['body'],
+			container: 'body',
 			text: ['are you a human?']
 		},
-		inStock: {
-			containers: ['#landingpage-cart .btn-primary span'],
+		inStock: [{
+			container: '#landingpage-cart .btn-primary span',
 			text: ['add to cart']
-		}
+		}]
 	},
 	links: [
 		{

--- a/src/store/model/nvidia-api.ts
+++ b/src/store/model/nvidia-api.ts
@@ -36,7 +36,7 @@ export const regionInfos = new Map<string, NvidiaRegionInfo>([
 export const NvidiaApi: Store = {
 	labels: {
 		inStock: {
-			container: 'body',
+			containers: ['body'],
 			text: ['product_inventory_in_stock']
 		}
 	},

--- a/src/store/model/nvidia-api.ts
+++ b/src/store/model/nvidia-api.ts
@@ -35,10 +35,10 @@ export const regionInfos = new Map<string, NvidiaRegionInfo>([
 
 export const NvidiaApi: Store = {
 	labels: {
-		inStock: {
-			containers: ['body'],
+		inStock: [{
+			container: 'body',
 			text: ['product_inventory_in_stock']
-		}
+		}]
 	},
 	links: generateLinks(),
 	name: 'nvidia-api',

--- a/src/store/model/nvidia.ts
+++ b/src/store/model/nvidia.ts
@@ -3,11 +3,11 @@ import {Store} from './store';
 export const Nvidia: Store = {
 	labels: {
 		captcha: {
-			container: 'body',
+			containers: ['body'],
 			text: ['are you a human?']
 		},
 		inStock: {
-			container: '.main-container',
+			containers: ['#herobanner .content-table', '.main-container'],
 			text: ['add to cart']
 		}
 	},
@@ -17,6 +17,12 @@ export const Nvidia: Store = {
 			model: 'test:model',
 			series: 'test:series',
 			url: 'https://www.nvidia.com/en-us/shop/geforce/gpu/'
+		},
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url: 'https://www.nvidia.com/en-us/geforce/graphics-cards/rtx-2060-super/'
 		},
 		{
 			brand: 'nvidia',

--- a/src/store/model/nvidia.ts
+++ b/src/store/model/nvidia.ts
@@ -7,7 +7,7 @@ export const Nvidia: Store = {
 			text: ['are you a human?']
 		},
 		inStock: {
-			containers: ['#herobanner .content-table', '.main-container'],
+			containers: ['.js-product-item .btn-cart', '.main-container'],
 			text: ['add to cart']
 		}
 	},

--- a/src/store/model/nvidia.ts
+++ b/src/store/model/nvidia.ts
@@ -3,13 +3,19 @@ import {Store} from './store';
 export const Nvidia: Store = {
 	labels: {
 		captcha: {
-			containers: ['body'],
+			container: 'body',
 			text: ['are you a human?']
 		},
-		inStock: {
-			containers: ['.js-product-item .btn-cart', '.main-container'],
-			text: ['add to cart']
-		}
+		inStock: [
+			{
+				container: '.js-product-item .btn-cart',
+				text: ['add to cart']
+			},
+			{
+				container: '.main-container',
+				text: ['add to cart']
+			}
+		]
 	},
 	links: [
 		{

--- a/src/store/model/officedepot.ts
+++ b/src/store/model/officedepot.ts
@@ -3,11 +3,11 @@ import {Store} from './store';
 export const OfficeDepot: Store = {
 	labels: {
 		captcha: {
-			container: 'body',
+			containers: ['body'],
 			text: ['please verify you are a human']
 		},
 		inStock: {
-			container: '#productPurchase',
+			containers: ['#productPurchase'],
 			text: ['add to cart']
 		}
 	},

--- a/src/store/model/officedepot.ts
+++ b/src/store/model/officedepot.ts
@@ -3,13 +3,15 @@ import {Store} from './store';
 export const OfficeDepot: Store = {
 	labels: {
 		captcha: {
-			containers: ['body'],
+			container: 'body',
 			text: ['please verify you are a human']
 		},
-		inStock: {
-			containers: ['#productPurchase'],
-			text: ['add to cart']
-		}
+		inStock: [
+			{
+				container: '#productPurchase',
+				text: ['add to cart']
+			}
+		]
 	},
 	links: [
 		{

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -1,7 +1,7 @@
 import {Browser, LoadEvent} from 'puppeteer';
 
 export type Element = {
-	containers: string[];
+	container: string;
 	text: string[];
 };
 
@@ -17,7 +17,7 @@ export type Link = {
 
 export type Labels = {
 	captcha?: Element;
-	inStock: Element;
+	inStock: Element[];
 };
 
 export type Store = {

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -1,7 +1,7 @@
 import {Browser, LoadEvent} from 'puppeteer';
 
 export type Element = {
-	container: string;
+	containers: string[];
 	text: string[];
 };
 

--- a/src/store/model/zotac.ts
+++ b/src/store/model/zotac.ts
@@ -3,7 +3,7 @@ import {Store} from './store';
 export const Zotac: Store = {
 	labels: {
 		inStock: {
-			container: '.add-to-cart-wrapper',
+			containers: ['.add-to-cart-wrapper'],
 			text: ['add to cart']
 		}
 	},

--- a/src/store/model/zotac.ts
+++ b/src/store/model/zotac.ts
@@ -2,10 +2,10 @@ import {Store} from './store';
 
 export const Zotac: Store = {
 	labels: {
-		inStock: {
-			containers: ['.add-to-cart-wrapper'],
+		inStock: [{
+			container: '.add-to-cart-wrapper',
 			text: ['add to cart']
-		}
+		}]
 	},
 	links: [
 		{


### PR DESCRIPTION
### Description

Closes #322 

* Changed store.labels config to allow multiple inStore containers
    * This helps for configs like `nvidia` store where a product list page and product details page are being searched, but the `'.main-container'` selector only works for the products list page (and a different container selector needs to be used for the product details page `'.js-product-item .btn-cart'`)

### Testing

* I added a second debug card in the `nvidia` store config for testing, and verified both debug pages are matching the 'add to cart' buttons and showing the "IN STOCK" alert

### New dependencies

N/A
