### PR TITLE
feat(store): add additional cards to all stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The purpose of this bot is to get an Nvidia card. It tries multiple things to do
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **3070**| | | | | | | | | | | | | | |
 | **3080** | `✔` | `✔` | `✔` | `✔` | `✔` | `✔` | `✔` | `✔` | `✔` | `✔` | `✔` | `✔` | `✔` | `✔` |
-| **3090** | | | `✔` | | | `✔` | `✔` | | | `✔` | `✔` | `✔` | | |
+| **3090** | `✔` | `✔` | `✔` | `✔` | `✔` | `✔` | `✔` | `✔` | | `✔` | `✔` | `✔` | | `✔` |
 
 ## Installation and prerequisites
 
@@ -204,7 +204,7 @@ Here is a list of variables that you can use to customize your newly copied `.en
 | russia | | | Missing all IDs |
 | spain | `✔` | | |
 | sweden | `✔` | | |
-| usa | `✔` | | Nvidia supports debug |
+| usa | `✔` | `✔` | Nvidia supports debug |
 
 ## FAQ
 

--- a/src/store/model/adorama.ts
+++ b/src/store/model/adorama.ts
@@ -71,6 +71,54 @@ export const Adorama: Store = {
 			model: 'xlr8 rbg',
 			series: '3080',
 			url: 'https://www.adorama.com/png30801tfxb.html'
+		},
+		{
+			brand: 'asus',
+			model: 'rog strix oc',
+			series: '3080',
+			url: 'https://www.adorama.com/asrx3080o10g.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3080',
+			url: 'https://www.adorama.com/astr3080o10g.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf',
+			series: '3080',
+			url: 'https://www.adorama.com/astrx308010g.html'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3090',
+			url: 'https://www.adorama.com/msig390gxt24.html'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3090',
+			url: 'https://www.adorama.com/msig39v3x24c.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf',
+			series: '3090',
+			url: 'https://www.adorama.com/asrtx309024g.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3090',
+			url: 'https://www.adorama.com/ast3090o24g.html'
+		},
+		{
+			brand: 'asus',
+			model: 'rog strix oc',
+			series: '3090',
+			url: 'https://www.adorama.com/asrx3090o24g.html'
 		}
 	],
 	name: 'adorama'

--- a/src/store/model/asus.ts
+++ b/src/store/model/asus.ts
@@ -25,6 +25,12 @@ export const Asus: Store = {
 			model: 'tuf',
 			series: '3080',
 			url: 'https://store.asus.com/us/item/202009AM150000004/'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf',
+			series: '3090',
+			url: 'https://store.asus.com/us/item/202009AM150000003/'
 		}
 	],
 	name: 'asus'

--- a/src/store/model/bandh.ts
+++ b/src/store/model/bandh.ts
@@ -63,6 +63,60 @@ export const BAndH: Store = {
 			model: 'ventus 3x oc - duplicate',
 			series: '3080',
 			url: 'https://www.bhphotovideo.com/c/product/1593646-REG/msi_geforce_rtx_3080_ventus.html'
+		},
+		{
+			brand: 'zotac',
+			model: 'trinity',
+			series: '3090',
+			url: 'https://www.bhphotovideo.com/c/product/1592970-REG/zotac_zt_a30900d_10p_gaming_geforce_rtx_3090.html'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3090',
+			url: 'https://www.bhphotovideo.com/c/product/1593647-REG/msi_geforce_rtx_3090_gaming.html'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3090',
+			url: 'https://www.bhphotovideo.com/c/product/1593994-REG/msi_g3090gxt24_geforce_rtx_3090_gaming.html'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3090',
+			url: 'https://www.bhphotovideo.com/c/product/1593648-REG/msi_geforce_rtx_3090_ventus.html'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3090',
+			url: 'https://www.bhphotovideo.com/c/product/1593995-REG/msi_g3090v3x24c_geforce_rtx_3090_ventus.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle oc',
+			series: '3090',
+			url: 'https://www.bhphotovideo.com/c/product/1593334-REG/gigabyte_gv_n3090eagle_oc_24gd_geforce_rtx_3090_eagle.html'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: '3090',
+			url: 'https://www.bhphotovideo.com/c/product/1593335-REG/gigabyte_gv_n3090gaming_oc_24gd_geforce_rtx3090_gaming_oc.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf',
+			series: '3090',
+			url: 'https://www.bhphotovideo.com/c/product/1594454-REG/asus_90yv0fd0_m0am00_tuf_gaming_geforce_rtx.html'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3090',
+			url: 'https://www.bhphotovideo.com/c/product/1594451-REG/asus_90yv0fd1_m0am00_tuf_gaming_geforce_rtx.html'
 		}
 	],
 	name: 'bandh'

--- a/src/store/model/bestbuy.ts
+++ b/src/store/model/bestbuy.ts
@@ -64,40 +64,74 @@ export const BestBuy: Store = {
 			url: 'https://www.bestbuy.com/site/msi-geforce-rtx-3080-ventus-3x-10g-oc-bv-gddr6x-pci-express-4-0-graphic-card-black-silver/6430175.p?skuId=6430175&intl=nosplash'
 		},
 		{
+			brand: 'pny',
+			cartUrl: 'https://api.bestbuy.com/click/-/6432655/cart',
+			model: 'xlr8 rgb',
+			series: '3080',
+			url: 'https://www.bestbuy.com/site/pny-geforce-rtx-3080-10gb-xlr8-gaming-epic-x-rgb-triple-fan-graphics-card/6432655.p?skuId=6432655&intl=nosplash'
+		},
+		{
+			brand: 'pny',
+			cartUrl: 'https://api.bestbuy.com/click/-/6432658/cart',
+			model: 'xlr8 rgb',
+			series: '3080',
+			url: 'https://www.bestbuy.com/site/pny-geforce-rtx-3080-10gb-xlr8-gaming-epic-x-rgb-triple-fan-graphics-card/6432658.p?skuId=6432658&intl=nosplash'
+		},
+		{
 			brand: 'nvidia',
+			cartUrl: 'https://api.bestbuy.com/click/-/6429434/cart',
 			model: 'founders edition',
 			series: '3090',
-			url: 'https://www.bestbuy.com/site/nvidia-geforce-rtx-3090-24gb-gddr6x-pci-express-4-0-graphics-card-titanium-and-black/6429434.p?skuId=6429434'
+			url: 'https://www.bestbuy.com/site/nvidia-geforce-rtx-3090-24gb-gddr6x-pci-express-4-0-graphics-card-titanium-and-black/6429434.p?skuId=6429434&intl=nosplash'
 		},
 		{
 			brand: 'asus',
+			cartUrl: 'https://api.bestbuy.com/click/-/6432447/cart',
 			model: 'rog strix',
 			series: '3090',
-			url: 'https://www.bestbuy.com/site/asus-geforce-rtx-3090-24gb-gddr6x-pci-express-4-0-strix-graphics-card-black/6432447.p?skuId=6432447'
+			url: 'https://www.bestbuy.com/site/asus-geforce-rtx-3090-24gb-gddr6x-pci-express-4-0-strix-graphics-card-black/6432447.p?skuId=6432447&intl=nosplash'
 		},
 		{
 			brand: 'asus',
+			cartUrl: 'https://api.bestbuy.com/click/-/6432446/cart',
 			model: 'tuf',
 			series: '3090',
-			url: 'https://www.bestbuy.com/site/asus-tuf-rtx-3090-24gb-gddr6x-pci-express-4-0-graphics-card-black/6432446.p?skuId=6432446'
+			url: 'https://www.bestbuy.com/site/asus-tuf-rtx-3090-24gb-gddr6x-pci-express-4-0-graphics-card-black/6432446.p?skuId=6432446&intl=nosplash'
 		},
 		{
 			brand: 'msi',
+			cartUrl: 'https://api.bestbuy.com/click/-/6430215/cart',
 			model: 'ventus 3x oc',
 			series: '3090',
-			url: 'https://www.bestbuy.com/site/msi-geforce-rtx-3090-ventus-3x-24g-oc-bv-24gb-gddr6x-pci-express-4-0-graphics-card-black-silver/6430215.p?skuId=6430215'
+			url: 'https://www.bestbuy.com/site/msi-geforce-rtx-3090-ventus-3x-24g-oc-bv-24gb-gddr6x-pci-express-4-0-graphics-card-black-silver/6430215.p?skuId=6430215&intl=nosplash'
 		},
 		{
 			brand: 'gigabyte',
+			cartUrl: 'https://api.bestbuy.com/click/-/6430623/cart',
 			model: 'gaming',
 			series: '3090',
-			url: 'https://www.bestbuy.com/site/gigabyte-geforce-rtx-3090-24g-gddr6x-pci-express-4-0-graphics-card-black/6430623.p?skuId=6430623'
+			url: 'https://www.bestbuy.com/site/gigabyte-geforce-rtx-3090-24g-gddr6x-pci-express-4-0-graphics-card-black/6430623.p?skuId=6430623&intl=nosplash'
 		},
 		{
 			brand: 'gigabyte',
+			cartUrl: 'https://api.bestbuy.com/click/-/6430624/cart',
 			model: 'eagle',
 			series: '3090',
-			url: 'https://www.bestbuy.com/site/gigabyte-geforce-rtx-3090-24g-gddr6x-pci-express-4-0-graphics-card-black/6430624.p?skuId=6430624'
+			url: 'https://www.bestbuy.com/site/gigabyte-geforce-rtx-3090-24g-gddr6x-pci-express-4-0-graphics-card-black/6430624.p?skuId=6430624&intl=nosplash'
+		},
+		{
+			brand: 'evga',
+			cartUrl: 'https://api.bestbuy.com/click/-/6434363/cart',
+			model: 'xc3',
+			series: '3090',
+			url: 'https://www.bestbuy.com/site/evga-geforce-rtx-3090-24gb-gddr6x-pci-express-4-0-graphics-card/6434363.p?skuId=6434363&intl=nosplash'
+		},
+		{
+			brand: 'pny',
+			cartUrl: 'https://api.bestbuy.com/click/-/6432657/cart',
+			model: 'xlr8 rgb',
+			series: '3090',
+			url: 'https://www.bestbuy.com/site/pny-geforce-rtx-3090-24gb-xlr8-gaming-epic-x-rgb-triple-fan-graphics-card/6432657.p?skuId=6432657&intl=nosplash'
 		}
 	],
 	name: 'bestbuy'

--- a/src/store/model/evga.ts
+++ b/src/store/model/evga.ts
@@ -43,6 +43,36 @@ export const Evga: Store = {
 			model: 'xc3 ultra',
 			series: '3080',
 			url: 'https://www.evga.com/products/product.aspx?pn=10G-P5-3885-KR'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 black',
+			series: '3090',
+			url: 'https://www.evga.com/products/product.aspx?pn=24G-P5-3971-KR'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3090',
+			url: 'https://www.evga.com/products/product.aspx?pn=24G-P5-3987-KR'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3',
+			series: '3090',
+			url: 'https://www.evga.com/products/product.aspx?pn=24G-P5-3985-KR'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3',
+			series: '3090',
+			url: 'https://www.evga.com/products/product.aspx?pn=24G-P5-3973-KR'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3090',
+			url: 'https://www.evga.com/products/product.aspx?pn=24G-P5-3975-KR'
 		}
 	],
 	name: 'evga'

--- a/src/store/model/newegg.ts
+++ b/src/store/model/newegg.ts
@@ -111,11 +111,25 @@ export const Newegg: Store = {
 			url: 'https://www.newegg.com/zotac-geforce-rtx-3080-zt-t30800j-10p/p/N82E16814500504'
 		},
 		{
+			brand: 'pny',
+			cartUrl: 'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814133809',
+			model: 'xlr8 rgb',
+			series: '3080',
+			url: 'https://www.newegg.com/pny-geforce-rtx-3080-vcg308010tfxppb/p/N82E16814133809'
+		},
+		{
 			brand: 'asus',
-			cartUrl: 'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=',
+			cartUrl: 'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814126455',
 			model: 'tuf',
 			series: '3090',
 			url: 'https://www.newegg.com/asus-geforce-rtx-3090-tuf-rtx3090-24g-gaming/p/N82E16814126455'
+		},
+		{
+			brand: 'asus',
+			cartUrl: 'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814126456',
+			model: 'rog strix',
+			series: '3090',
+			url: 'https://www.newegg.com/asus-geforce-rtx-3090-rog-strix-rtx3090-o24g-gaming/p/N82E16814126456'
 		},
 		{
 			brand: 'msi',
@@ -165,6 +179,20 @@ export const Newegg: Store = {
 			model: 'ftw3 ultra gaming',
 			series: '3090',
 			url: 'https://www.newegg.com/evga-geforce-rtx-3090-24g-p5-3987-kr/p/N82E16814487526'
+		},
+		{
+			brand: 'evga',
+			cartUrl: 'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814487527',
+			model: 'xc3 black',
+			series: '3090',
+			url: 'https://www.newegg.com/evga-geforce-rtx-3090-24g-p5-3971-kr/p/N82E16814487527'
+		},
+		{
+			brand: 'evga',
+			cartUrl: 'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814487523',
+			model: 'xc3',
+			series: '3090',
+			url: 'https://www.newegg.com/evga-geforce-rtx-3090-24g-p5-3973-kr/p/N82E16814487523'
 		},
 		{
 			brand: 'gigabyte',

--- a/src/store/model/nvidia-api.ts
+++ b/src/store/model/nvidia-api.ts
@@ -30,7 +30,7 @@ export const regionInfos = new Map<string, NvidiaRegionInfo>([
 	['russia', {drLocale: 'ru_ru', fe2060SuperId: null, fe3080Id: null, fe3090Id: null, nvidiaLocale: 'ru_ru'}],
 	['spain', {drLocale: 'es_es', fe2060SuperId: null, fe3080Id: 5438794800, fe3090Id: null, nvidiaLocale: 'es_es'}],
 	['sweden', {drLocale: 'sv_SE', fe2060SuperId: null, fe3080Id: 5438798100, fe3090Id: null, nvidiaLocale: 'sv_se'}],
-	['usa', {drLocale: 'en_us', fe2060SuperId: 5379432500, fe3080Id: 5438481700, fe3090Id: null, nvidiaLocale: 'en_us'}]
+	['usa', {drLocale: 'en_us', fe2060SuperId: 5379432500, fe3080Id: 5438481700, fe3090Id: 5438481600, nvidiaLocale: 'en_us'}]
 ]);
 
 export const NvidiaApi: Store = {

--- a/src/store/model/zotac.ts
+++ b/src/store/model/zotac.ts
@@ -25,6 +25,12 @@ export const Zotac: Store = {
 			model: 'trinity OC',
 			series: '3080',
 			url: 'https://store.zotac.com/zotac-gaming-geforce-rtx-3080-trinity-oc-zt-a30800j-10p'
+		},
+		{
+			brand: 'zotac',
+			model: 'trinity',
+			series: '3090',
+			url: 'https://store.zotac.com/zotac-gaming-geforce-rtx-3090-trinity-zt-a30900d-10p'
 		}
 	],
 	name: 'zotac'


### PR DESCRIPTION
### Description

- Adds additional 3080 and 3090 cards to adorama, asus, bestbuy, b&h, evga, newegg, zotac
- Adds 3090 FE ID for `en-us` on Nvidia API
- Updates existing 3090 cards from `bestbuy` with add to cart link
- Adds `intl=nosplash` to existing 3090 links in `bestbuy`

### Testing

Ran locally and verified that new cards were monitored

### New dependencies

N/A
