### PR TITLE
chore: remove nvidiaLocale

### DIFF
--- a/src/store/model/helpers/nvidia.ts
+++ b/src/store/model/helpers/nvidia.ts
@@ -33,8 +33,8 @@ interface NvidiaAddToCardJSON {
 	location: string;
 }
 
-function nvidiaSessionUrl(nvidiaLocale: string): string {
-	return `https://store.nvidia.com/store/nvidia/SessionToken?format=json&locale=${nvidiaLocale}` +
+function nvidiaSessionUrl(drLocale: string): string {
+	return `https://store.nvidia.com/store/nvidia/SessionToken?format=json&locale=${drLocale}` +
 		timestampUrlParameter();
 }
 
@@ -75,7 +75,7 @@ function fallbackCartUrl(nvidiaLocale: string): string {
 	return `https://www.nvidia.com/${nvidiaLocale}/shop/geforce?${timestampUrlParameter()}`;
 }
 
-export function generateOpenCartAction(id: number, nvidiaLocale: string, drLocale: string, cardName: string) {
+export function generateOpenCartAction(id: number, drLocale: string, cardName: string) {
 	return async (browser: Browser) => {
 		const page = await browser.newPage();
 
@@ -86,7 +86,7 @@ export function generateOpenCartAction(id: number, nvidiaLocale: string, drLocal
 		try {
 			Logger.info(`🚀🚀🚀 [nvidia] ${cardName}, getting access token 🚀🚀🚀`);
 
-			response = await page.goto(nvidiaSessionUrl(nvidiaLocale), {waitUntil: 'networkidle0'});
+			response = await page.goto(nvidiaSessionUrl(drLocale), {waitUntil: 'networkidle0'});
 			if (response === null) {
 				throw new Error('NvidiaAccessTokenUnavailable');
 			}
@@ -106,7 +106,7 @@ export function generateOpenCartAction(id: number, nvidiaLocale: string, drLocal
 			Logger.debug(error);
 			Logger.error(`✖ [nvidia] ${cardName} could not automatically add to cart, opening page`, error);
 
-			cartUrl = fallbackCartUrl(nvidiaLocale);
+			cartUrl = fallbackCartUrl(drLocale);
 			await open(cartUrl);
 		}
 
@@ -117,7 +117,7 @@ export function generateOpenCartAction(id: number, nvidiaLocale: string, drLocal
 }
 
 export function generateLinks(): Link[] {
-	const {drLocale, nvidiaLocale, fe3080Id, fe3090Id, fe2060SuperId, currency} = getRegionInfo();
+	const {drLocale, fe3080Id, fe3090Id, fe2060SuperId, currency} = getRegionInfo();
 
 	const links: Link[] = [];
 
@@ -125,7 +125,7 @@ export function generateLinks(): Link[] {
 		links.push({
 			brand: 'test:brand',
 			model: 'test:model',
-			openCartAction: generateOpenCartAction(fe2060SuperId, nvidiaLocale, drLocale, 'TEST CARD debug'),
+			openCartAction: generateOpenCartAction(fe2060SuperId, drLocale, 'TEST CARD debug'),
 			series: 'test:series',
 			url: nvidiaStockUrl(fe2060SuperId, drLocale, currency)
 		});
@@ -135,7 +135,7 @@ export function generateLinks(): Link[] {
 		links.push({
 			brand: 'nvidia',
 			model: 'founders edition',
-			openCartAction: generateOpenCartAction(fe3080Id, nvidiaLocale, drLocale, 'nvidia founders edition 3080'),
+			openCartAction: generateOpenCartAction(fe3080Id, drLocale, 'nvidia founders edition 3080'),
 			series: '3080',
 			url: nvidiaStockUrl(fe3080Id, drLocale, currency)
 		});
@@ -145,7 +145,7 @@ export function generateLinks(): Link[] {
 		links.push({
 			brand: 'nvidia',
 			model: 'founders edition',
-			openCartAction: generateOpenCartAction(fe3090Id, nvidiaLocale, drLocale, 'nvidia founders edition 3090'),
+			openCartAction: generateOpenCartAction(fe3090Id, drLocale, 'nvidia founders edition 3090'),
 			series: '3090',
 			url: nvidiaStockUrl(fe3090Id, drLocale, currency)
 		});

--- a/src/store/model/nvidia-api.ts
+++ b/src/store/model/nvidia-api.ts
@@ -9,29 +9,28 @@ export interface NvidiaRegionInfo {
 	fe3080Id: number | null;
 	fe3090Id: number | null;
 	fe2060SuperId: number | null;
-	nvidiaLocale: string;
 }
 
 export const regionInfos = new Map<string, NvidiaRegionInfo>([
-	['austria', {currency: 'EUR', drLocale: 'de_de', fe2060SuperId: null, fe3080Id: 5440853700, fe3090Id: null, nvidiaLocale: 'de_de'}],
-	['belgium', {currency: 'EUR', drLocale: 'fr_fr', fe2060SuperId: 5394902700, fe3080Id: 5438795700, fe3090Id: null, nvidiaLocale: 'fr_fr'}],
-	['canada', {currency: 'CAD', drLocale: 'en_us', fe2060SuperId: null, fe3080Id: 5438481700, fe3090Id: null, nvidiaLocale: 'en_ca'}],
-	['czechia', {currency: 'CZK', drLocale: 'en_gb', fe2060SuperId: null, fe3080Id: 5438793800, fe3090Id: null, nvidiaLocale: 'en_gb'}],
-	['denmark', {currency: 'EUR', drLocale: 'en_gb', fe2060SuperId: null, fe3080Id: 5438793300, fe3090Id: null, nvidiaLocale: 'en_gb'}],
-	['finland', {currency: 'EUR', drLocale: 'en_gb', fe2060SuperId: null, fe3080Id: 5438793300, fe3090Id: null, nvidiaLocale: 'en_gb'}],
-	['france', {currency: 'EUR', drLocale: 'fr_fr', fe2060SuperId: null, fe3080Id: 5438795200, fe3090Id: null, nvidiaLocale: 'fr_fr'}],
-	['germany', {currency: 'EUR', drLocale: 'de_de', fe2060SuperId: null, fe3080Id: 5438792300, fe3090Id: null, nvidiaLocale: 'de_de'}],
-	['great_britain', {currency: 'GBP', drLocale: 'en_gb', fe2060SuperId: null, fe3080Id: 5438792800, fe3090Id: null, nvidiaLocale: 'en_gb'}],
-	['ireland', {currency: 'GBP', drLocale: 'en_gb', fe2060SuperId: null, fe3080Id: 5438792800, fe3090Id: null, nvidiaLocale: 'en_gb'}],
-	['italy', {currency: 'EUR', drLocale: 'it_it', fe2060SuperId: null, fe3080Id: 5438796200, fe3090Id: null, nvidiaLocale: 'it_it'}],
-	['luxembourg', {currency: 'EUR', drLocale: 'fr_fr', fe2060SuperId: 5394902700, fe3080Id: 5438795700, fe3090Id: null, nvidiaLocale: 'fr_fr'}],
-	['netherlands', {currency: 'EUR', drLocale: 'nl_nl', fe2060SuperId: 5394903500, fe3080Id: 5438796700, fe3090Id: null, nvidiaLocale: 'nl_nl'}],
-	['poland', {currency: 'PLN', drLocale: 'pl_pl', fe2060SuperId: null, fe3080Id: 5438797700, fe3090Id: null, nvidiaLocale: 'pl_pSl'}],
-	['portugal', {currency: 'EUR', drLocale: 'en_gb', fe2060SuperId: null, fe3080Id: 5438794300, fe3090Id: null, nvidiaLocale: 'en_gb'}],
-	['russia', {currency: 'RUB', drLocale: 'ru_ru', fe2060SuperId: null, fe3080Id: null, fe3090Id: null, nvidiaLocale: 'ru_ru'}],
-	['spain', {currency: 'EUR', drLocale: 'es_es', fe2060SuperId: null, fe3080Id: 5438794800, fe3090Id: null, nvidiaLocale: 'es_es'}],
-	['sweden', {currency: 'SEK', drLocale: 'sv_se', fe2060SuperId: null, fe3080Id: 5438798100, fe3090Id: null, nvidiaLocale: 'sv_se'}],
-	['usa', {currency: 'USD', drLocale: 'en_us', fe2060SuperId: 5379432500, fe3080Id: 5438481700, fe3090Id: 5438481600, nvidiaLocale: 'en_us'}]
+	['austria', {currency: 'EUR', drLocale: 'de_de', fe2060SuperId: null, fe3080Id: 5440853700, fe3090Id: null}],
+	['belgium', {currency: 'EUR', drLocale: 'fr_fr', fe2060SuperId: 5394902700, fe3080Id: 5438795700, fe3090Id: null}],
+	['canada', {currency: 'CAD', drLocale: 'en_us', fe2060SuperId: null, fe3080Id: 5438481700, fe3090Id: null}],
+	['czechia', {currency: 'CZK', drLocale: 'en_gb', fe2060SuperId: null, fe3080Id: 5438793800, fe3090Id: null}],
+	['denmark', {currency: 'EUR', drLocale: 'en_gb', fe2060SuperId: null, fe3080Id: 5438793300, fe3090Id: null}],
+	['finland', {currency: 'EUR', drLocale: 'en_gb', fe2060SuperId: null, fe3080Id: 5438793300, fe3090Id: null}],
+	['france', {currency: 'EUR', drLocale: 'fr_fr', fe2060SuperId: null, fe3080Id: 5438795200, fe3090Id: null}],
+	['germany', {currency: 'EUR', drLocale: 'de_de', fe2060SuperId: null, fe3080Id: 5438792300, fe3090Id: null}],
+	['great_britain', {currency: 'GBP', drLocale: 'en_gb', fe2060SuperId: null, fe3080Id: 5438792800, fe3090Id: null}],
+	['ireland', {currency: 'GBP', drLocale: 'en_gb', fe2060SuperId: null, fe3080Id: 5438792800, fe3090Id: null}],
+	['italy', {currency: 'EUR', drLocale: 'it_it', fe2060SuperId: null, fe3080Id: 5438796200, fe3090Id: null}],
+	['luxembourg', {currency: 'EUR', drLocale: 'fr_fr', fe2060SuperId: 5394902700, fe3080Id: 5438795700, fe3090Id: null}],
+	['netherlands', {currency: 'EUR', drLocale: 'nl_nl', fe2060SuperId: 5394903500, fe3080Id: 5438796700, fe3090Id: null}],
+	['poland', {currency: 'PLN', drLocale: 'pl_pl', fe2060SuperId: null, fe3080Id: 5438797700, fe3090Id: null}],
+	['portugal', {currency: 'EUR', drLocale: 'en_gb', fe2060SuperId: null, fe3080Id: 5438794300, fe3090Id: null}],
+	['russia', {currency: 'RUB', drLocale: 'ru_ru', fe2060SuperId: null, fe3080Id: null, fe3090Id: null}],
+	['spain', {currency: 'EUR', drLocale: 'es_es', fe2060SuperId: null, fe3080Id: 5438794800, fe3090Id: null}],
+	['sweden', {currency: 'SEK', drLocale: 'sv_se', fe2060SuperId: null, fe3080Id: 5438798100, fe3090Id: null}],
+	['usa', {currency: 'USD', drLocale: 'en_us', fe2060SuperId: 5379432500, fe3080Id: 5438481700, fe3090Id: 5438481600}]
 ]);
 
 export const NvidiaApi: Store = {


### PR DESCRIPTION
Follow-up to comment in #314; I think `drLocale` is the correct locale in all instances, e.g. the Nvidia site uses `en-us` for Canada. The only other difference was Poland where #306 will remove `pl_pSl` anyway as it appears to have been a typo.