### PR TITLE
feat(store): nvidia debug card for "product details" page

### DIFF
--- a/src/store/model/nvidia.ts
+++ b/src/store/model/nvidia.ts
@@ -6,16 +6,10 @@ export const Nvidia: Store = {
 			container: 'body',
 			text: ['are you a human?']
 		},
-		inStock: [
-			{
-				container: '.js-product-item .btn-cart',
-				text: ['add to cart']
-			},
-			{
-				container: '.main-container',
-				text: ['add to cart']
-			}
-		]
+		inStock: {
+			container: '.main-container',
+			text: ['add to cart']
+		}
 	},
 	links: [
 		{

--- a/src/store/model/nvidia.ts
+++ b/src/store/model/nvidia.ts
@@ -6,10 +6,16 @@ export const Nvidia: Store = {
 			container: 'body',
 			text: ['are you a human?']
 		},
-		inStock: {
-			container: '.main-container',
-			text: ['add to cart']
-		}
+		inStock: [
+			{
+				container: '.js-product-item .btn-cart',
+				text: ['add to cart']
+			},
+			{
+				container: '.main-container',
+				text: ['add to cart']
+			}
+		]
 	},
 	links: [
 		{
@@ -17,6 +23,12 @@ export const Nvidia: Store = {
 			model: 'test:model',
 			series: 'test:series',
 			url: 'https://www.nvidia.com/en-us/shop/geforce/gpu/'
+		},
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url: 'https://www.nvidia.com/en-us/geforce/graphics-cards/rtx-2060-super/'
 		},
 		{
 			brand: 'nvidia',


### PR DESCRIPTION
### Description

* Adding 2060 super debug card for nvidia store
  * https://www.nvidia.com/en-us/geforce/graphics-cards/rtx-2060-super/
* Compliments https://github.com/jef/nvidia-snatcher/pull/333 by providing an in-stock card to verify the inStock label configuration matches as expected on the nvidia "product details" pages

### Testing

* Tested the 2060 super debug card

### New dependencies

* N/A
