### PR TITLE
Adds support for .env config path supplied via cmd line

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "rimraf ./build && tsc",
     "lint": "xo",
     "lint:fix": "xo --fix",
-    "start": "npm run build && node build/index.js",
+    "start": "npm run build && node -r dotenv/config build/index.js",
     "start:dev": "nodemon --config nodemon.json",
     "test:notification": "npm run build && node build/__test__/notification-test.js"
   },


### PR DESCRIPTION
### Description

Preloading dotenv allows us to specify a .env config path on start such as: `npm start dotenv_config_path=./.env.normal`

This is useful for those of us that want to run multiple instances of the snatcher in the same folder.

Not supplying a dotenv_config_path makes the script use default value of .env in root.

### Testing

Tested with and without dotenv_config_path.
