### PR TITLE
fix: corrected norway locales

### DIFF
--- a/src/store/model/nvidia-api.ts
+++ b/src/store/model/nvidia-api.ts
@@ -26,7 +26,7 @@ export const regionInfos = new Map<string, NvidiaRegionInfo>([
 	['italy', {currency: 'EUR', drLocale: 'it_it', fe2060SuperId: 5394903400, fe3080Id: 5438796200, fe3090Id: 5438796100, siteLocale: 'it-it'}],
 	['luxembourg', {currency: 'EUR', drLocale: 'fr_fr', fe2060SuperId: 5394902700, fe3080Id: 5438795700, fe3090Id: 5438795600, siteLocale: 'fr-be'}],
 	['netherlands', {currency: 'EUR', drLocale: 'nl_nl', fe2060SuperId: 5394903500, fe3080Id: 5438796700, fe3090Id: 5438796600, siteLocale: 'nl-nl'}],
-	['norway', {currency: 'EUR', drLocale: 'nb_no', fe2060SuperId: 5394903600, fe3080Id: 5438797200, fe3090Id: 5438797100, siteLocale: 'nb-no'}],
+	['norway', {currency: 'NOK', drLocale: 'no_no', fe2060SuperId: 5394903600, fe3080Id: 5438797200, fe3090Id: 5438797100, siteLocale: 'nb-no'}],
 	['poland', {currency: 'PLN', drLocale: 'pl_pl', fe2060SuperId: 5394903700, fe3080Id: 5438797700, fe3090Id: 5438797600, siteLocale: 'pl-pl'}],
 	['portugal', {currency: 'EUR', drLocale: 'en_gb', fe2060SuperId: null, fe3080Id: 5438794300, fe3090Id: null, siteLocale: 'en-gb'}],
 	['russia', {currency: 'RUB', drLocale: 'ru_ru', fe2060SuperId: null, fe3080Id: null, fe3090Id: null, siteLocale: 'ru-ru'}],


### PR DESCRIPTION
### Description

norway currency should be `NOK` not `EUR`
norway drLocale should be `no_no` not `nb_no`

_3080 example:_
Previous API url that nvidia.ts would call ended up beeing: 
https://api-prod.nvidia.com/direct-sales-shop/DR/products/nb_no/EUR/5438797200
this URL ends in **status: "failure"**

New fixed API url that nvidia.ts is calling: 
https://api-prod.nvidia.com/direct-sales-shop/DR/products/no_no/NOK/5438797200
This URL is correct

### Testing

Tested with no errors

