### PR TITLE
chore: normalize ftw3 naming

### DIFF
--- a/src/store/model/newegg.ts
+++ b/src/store/model/newegg.ts
@@ -176,7 +176,7 @@ export const Newegg: Store = {
 		{
 			brand: 'evga',
 			cartUrl: 'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814487525',
-			model: 'ftw3 gaming',
+			model: 'ftw3',
 			series: '3090',
 			url: 'https://www.newegg.com/evga-geforce-rtx-3090-24g-p5-3985-kr/p/N82E16814487525'
 		},
@@ -190,7 +190,7 @@ export const Newegg: Store = {
 		{
 			brand: 'evga',
 			cartUrl: 'https://secure.newegg.com/Shopping/AddtoCart.aspx?Submit=ADD&ItemList=N82E16814487526',
-			model: 'ftw3 ultra gaming',
+			model: 'ftw3 ultra',
 			series: '3090',
 			url: 'https://www.newegg.com/evga-geforce-rtx-3090-24g-p5-3987-kr/p/N82E16814487526'
 		},


### PR DESCRIPTION
3090 ftw3 and ftw3 ultra were listed as ftw3 gaming and ftw3 ultra gaming. Removed gaming to bring them inline with the model name used everywhere else (as far as I can find).