### PR TITLE
Multiplesms

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -86,8 +86,8 @@ const notifications = {
 			['virgin', 'vmobl.com'],
 			['virgin-ca', 'vmobile.ca']
 		]),
-		carrier: envOrString(process.env.PHONE_CARRIER),
-		number: envOrString(process.env.PHONE_NUMBER)
+		carriers: envOrString(process.env.PHONE_CARRIER),
+		numbers: envOrString(process.env.PHONE_NUMBER)
 	},
 	playSound: envOrString(process.env.PLAY_SOUND),
 	pushBulletApiKey: envOrString(process.env.PUSHBULLET),

--- a/src/notification/notification.ts
+++ b/src/notification/notification.ts
@@ -21,12 +21,22 @@ export function sendNotification(link: Link, store: Store) {
 		sendEmail(link, store);
 	}
 
-	if (notifications.phone.number) {
+	if (notifications.phone.numbers) {
 		Logger.debug('↗ sending sms');
-		const carrier = notifications.phone.carrier;
-		if (carrier && notifications.phone.availableCarriers.has(carrier)) {
-			sendSMS(link, store);
+
+		const carriers: any[] = notifications.phone.carriers.split(',');
+		const numbers: any[] = notifications.phone.numbers.split(',');
+
+		if (carriers.length !== numbers.length) {
+			Logger.error(`✖ couldn't send sms. The amount of numbers(${numbers.length}) does not match the amount of carriers(${carriers.length}). \n PHONE_NUMBER="9998887777,6665554444"\n PHONE_CARRIER="att,verizon".`);
 		}
+
+		carriers.forEach((carrier, i) => {
+			const number: string = numbers[i];
+			if (carrier && notifications.phone.availableCarriers.has(carrier)) {
+				sendSMS(link, store, carrier, number);
+			}
+		});
 	}
 
 	if (notifications.playSound) {

--- a/src/notification/sms.ts
+++ b/src/notification/sms.ts
@@ -18,7 +18,7 @@ const transporter = nodemailer.createTransport({
 	service: 'gmail'
 });
 export function sendSMS(link: Link, store: Store, carrier: string, number: string) {
-	const address = generateAddress(carrier, number);
+	const address: string = generateAddress(carrier, number);
 	const mailOptions: Mail.Options = {
 		attachments: link.screenshot ? [
 			{
@@ -40,9 +40,11 @@ export function sendSMS(link: Link, store: Store, carrier: string, number: strin
 	});
 }
 
-function generateAddress(carrier: string, number: string) {
+function generateAddress(carrier: string, number: string): string {
 	if (carrier && phone.availableCarriers.has(carrier)) {
 		return [number, phone.availableCarriers.get(carrier)].join('@').concat(';');
 	}
+
 	Logger.error('✖ unknown carrier', carrier);
+	return '';
 }

--- a/src/notification/sms.ts
+++ b/src/notification/sms.ts
@@ -18,7 +18,7 @@ const transporter = nodemailer.createTransport({
 	service: 'gmail'
 });
 export function sendSMS(link: Link, store: Store, carrier: string, number: string) {
-	const toAddress: string = generateAddress(carrier, number);
+	const address = generateAddress(carrier, number);
 	const mailOptions: Mail.Options = {
 		attachments: link.screenshot ? [
 			{
@@ -29,22 +29,20 @@ export function sendSMS(link: Link, store: Store, carrier: string, number: strin
 		from: email.username,
 		subject: Print.inStock(link, store, false, true),
 		text: link.cartUrl ? link.cartUrl : link.url,
-		to: toAddress
+		to: address
 	};
 	transporter.sendMail(mailOptions, error => {
 		if (error) {
 			Logger.error('✖ couldn\'t send sms', error);
 		} else {
-			Logger.info(`✔ sms sent to: ${toAddress}`);
+			Logger.info(`✔ sms sent to: ${address}`);
 		}
 	});
 }
 
 function generateAddress(carrier: string, number: string) {
 	if (carrier && phone.availableCarriers.has(carrier)) {
-		Logger.info([number, phone.availableCarriers.get(carrier)].join('@').concat(';'));
 		return [number, phone.availableCarriers.get(carrier)].join('@').concat(';');
 	}
-
 	Logger.error('✖ unknown carrier', carrier);
 }


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

feat: allows multiple phone numbers/carriers for multiple sms texts to be sent out on alerts, delimited by commas.

EX in `.env`

| VARIABLE | VALUE |
| --- | --- |
| PHONE_NUMBER= | "9998887777,5554443333" |
| PHONE_CARRIER= | "verzion,verizon" |

`info :: ✔ sms sent to: 9998887777@vtext.com;`
`info :: ✔ sms sent to: 5554443333@vtext.com;`

### Testing

Ran npm run test:notification and successfully is able to retrieve multiple text messages on multiple devices.