### PR TITLE
feat(store): add asus strix oc to asus store

### DIFF
--- a/src/store/model/asus.ts
+++ b/src/store/model/asus.ts
@@ -31,6 +31,12 @@ export const Asus: Store = {
 			model: 'tuf',
 			series: '3090',
 			url: 'https://store.asus.com/us/item/202009AM150000003/'
+		},
+		{
+			brand: 'asus',
+			model: 'strix',
+			series: '3090',
+			url: 'https://store.asus.com/us/item/202009AM290000002/'
 		}
 	],
 	name: 'asus',

--- a/src/store/model/asus.ts
+++ b/src/store/model/asus.ts
@@ -34,8 +34,8 @@ export const Asus: Store = {
 		},
 		{
 			brand: 'asus',
-			model: 'strix',
-			series: '3090',
+			model: 'strix oc',
+			series: '3080',
 			url: 'https://store.asus.com/us/item/202009AM290000002/'
 		}
 	],


### PR DESCRIPTION
### Description

Fixes #382


### Testing

Verified link is working fine in the snatcher by running it locally for hours. 
Not sure on link for regular Asus Strix 3080 otherwise I would have added it.

