### PR TITLE
feat(store): add evga 3090 to newegg canada

### DIFF
--- a/src/store/model/newegg-ca.ts
+++ b/src/store/model/newegg-ca.ts
@@ -1,4 +1,4 @@
-import { Store } from './store';
+import {Store} from './store';
 
 export const NeweggCa: Store = {
 	labels: {

--- a/src/store/model/newegg-ca.ts
+++ b/src/store/model/newegg-ca.ts
@@ -1,4 +1,4 @@
-import {Store} from './store';
+import { Store } from './store';
 
 export const NeweggCa: Store = {
 	labels: {
@@ -113,6 +113,30 @@ export const NeweggCa: Store = {
 			model: 'rog strix',
 			series: '3090',
 			url: 'https://www.newegg.ca/asus-geforce-rtx-3090-rog-strix-rtx3090-o24g-gaming/p/N82E16814126456'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3090',
+			url: 'https://www.newegg.ca/evga-geforce-rtx-3090-24g-p5-3975-kr/p/N82E16814487524'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3',
+			series: '3090',
+			url: 'https://www.newegg.ca/evga-geforce-rtx-3090-24g-p5-3973-kr/p/N82E16814487523'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3090',
+			url: 'https://www.newegg.ca/evga-geforce-rtx-3090-24g-p5-3987-kr/p/N82E16814487526'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3',
+			series: '3090',
+			url: 'https://www.newegg.ca/evga-geforce-rtx-3090-24g-p5-3985-kr/p/N82E16814487525'
 		}
 	],
 	name: 'newegg-ca'


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
Adds EVGA 3090 xc3 ultra, xc3, ftw3 ultra and ftw3 to newegg.ca

Fixes #388  kind of, there are currently no evga 3090 cards listed on bestbuy.ca         

### Testing
Ran snatcher only looking for evga 3090 products and verified all links work.
![image](https://user-images.githubusercontent.com/48081699/94739701-9c43cc80-032e-11eb-8cde-6d3ab9e4d0df.png)

