### PR TITLE
feat(notification): add at&t prepaid carrier

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -73,6 +73,7 @@ const notifications = {
 	phone: {
 		availableCarriers: new Map([
 			['att', 'txt.att.net'],
+			['attgo', 'mms.att.net'],
 			['bell', 'txt.bell.ca'],
 			['fido', 'fido.ca'],
 			['google', 'msg.fi.google.com'],


### PR DESCRIPTION
feat: Add ATT prepaid to supported carriers.

### Description

Added ATT Prepaid SMS notifications support.

### Testing

Ran notification test, received text on my cell phone on ATT Prepaid.
