### PR TITLE
fix(store): update `inStock` and `maxPrice` for newegg, newegg-ca

### DIFF
--- a/src/store/model/newegg-ca.ts
+++ b/src/store/model/newegg-ca.ts
@@ -7,11 +7,11 @@ export const NeweggCa: Store = {
 			text: ['are you a human?']
 		},
 		inStock: {
-			container: '#landingpage-cart .btn-primary span',
+			container: 'div#ProductBuy .btn-primary',
 			text: ['add to cart']
 		},
 		maxPrice: {
-			container: '#landingpage-price > div > div > ul > li.price-current > strong',
+			container: 'div#app div.product-price > ul > li.price-current > strong',
 			euroFormat: false
 		}
 	},

--- a/src/store/model/newegg.ts
+++ b/src/store/model/newegg.ts
@@ -7,11 +7,11 @@ export const Newegg: Store = {
 			text: ['are you a human?']
 		},
 		inStock: {
-			container: '#landingpage-cart .btn-primary span',
+			container: 'div#ProductBuy .btn-primary',
 			text: ['add to cart']
 		},
 		maxPrice: {
-			container: '#landingpage-price > div > div > ul > li.price-current > strong',
+			container: 'div#app div.product-price > ul > li.price-current > strong',
 			euroFormat: false
 		}
 	},


### PR DESCRIPTION
### Description

Fixes #400 

### Testing

Verified updated `inStock` and `maxPrice` selectors are working correctly, running against multiple products and price ranges for both stores (newegg and newegg-ca)

