### PR TITLE
feat: add asus-de store and asus 3080 tuf/oc to amazon-de

### DIFF
--- a/src/store/model/amazon-de.ts
+++ b/src/store/model/amazon-de.ts
@@ -86,6 +86,12 @@ export const AmazonDe: Store = {
 			brand: 'asus',
 			model: 'tuf',
 			series: '3080',
+			url: 'https://www.amazon.de/dp/B08HN37VQK'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3080',
 			url: 'https://www.amazon.de/dp/B08HN4DSTC'
 		},
 		{

--- a/src/store/model/asus-de.ts
+++ b/src/store/model/asus-de.ts
@@ -28,6 +28,18 @@ export const AsusDe: Store = {
 		},
 		{
 			brand: 'asus',
+			model: 'rog strix',
+			series: '3080',
+			url: 'https://webshop.asus.com/de/komponenten/grafikkarten/nvidia-serie/2828/asus-rog-strix-rtx3080-10g-gaming'
+		},
+		{
+			brand: 'asus',
+			model: 'rog strix oc',
+			series: '3080',
+			url: 'https://webshop.asus.com/de/komponenten/grafikkarten/nvidia-serie/2829/asus-rog-strix-rtx3080-o10g-gaming'
+		},
+		{
+			brand: 'asus',
 			model: 'tuf oc',
 			series: '3090',
 			url: 'https://webshop.asus.com/de/komponenten/grafikkarten/nvidia-serie/2823/asus-tuf-rtx3090-o24g-gaming'
@@ -43,6 +55,12 @@ export const AsusDe: Store = {
 			model: 'rog strix',
 			series: '3090',
 			url: 'https://webshop.asus.com/de/komponenten/grafikkarten/nvidia-serie/2826/asus-rog-strix-rtx3090-24g-gaming'
+		},
+		{
+			brand: 'asus',
+			model: 'rog strix oc',
+			series: '3090',
+			url: 'https://webshop.asus.com/de/komponenten/grafikkarten/nvidia-serie/2827/asus-rog-strix-rtx3090-o24g-gaming'
 		}
 	],
 	name: 'asus-de'

--- a/src/store/model/asus-de.ts
+++ b/src/store/model/asus-de.ts
@@ -1,0 +1,50 @@
+import {Store} from './store';
+
+export const AsusDe: Store = {
+	labels: {
+		inStock: {
+			container: '.buybox--button',
+			text: ['in den warenkorb']
+		}
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			model: 'test:model',
+			series: 'test:series',
+			url: 'https://webshop.asus.com/de/komponenten/grafikkarten/nvidia-serie/2766/asus-rog-strix-rtx2060s-o8g-evo-v2-gaming'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3080',
+			url: 'https://webshop.asus.com/de/komponenten/grafikkarten/nvidia-serie/2825/asus-tuf-rtx3080-o10g-gaming'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf',
+			series: '3080',
+			url: 'https://webshop.asus.com/de/komponenten/grafikkarten/nvidia-serie/2824/asus-tuf-rtx3080-10g-gaming'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3090',
+			url: 'https://webshop.asus.com/de/komponenten/grafikkarten/nvidia-serie/2823/asus-tuf-rtx3090-o24g-gaming'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf',
+			series: '3090',
+			url: 'https://webshop.asus.com/de/komponenten/grafikkarten/nvidia-serie/2822/asus-tuf-rtx3090-24g-gaming'
+		},
+		{
+			brand: 'asus',
+			model: 'rog strix',
+			series: '3090',
+			url: 'https://webshop.asus.com/de/komponenten/grafikkarten/nvidia-serie/2826/asus-rog-strix-rtx3090-24g-gaming'
+		}
+	],
+	name: 'asus-de'
+};
+

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -53,7 +53,7 @@ for (const name of Config.store.stores) {
 	if (masterList.has(name)) {
 		list.set(name, masterList.get(name));
 	} else {
-		const logString = ` ${name}, skipping.`;
+		const logString = `No store named ${name}, skipping.`;
 		Logger.warn(logString);
 	}
 }

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -4,6 +4,7 @@ import {AmazonCa} from './amazon-ca';
 import {AmazonDe} from './amazon-de';
 import {AmazonNl} from './amazon-nl';
 import {Asus} from './asus';
+import {AsusDe} from './asus-de';
 import {BAndH} from './bandh';
 import {BestBuy} from './bestbuy';
 import {BestBuyCa} from './bestbuy-ca';
@@ -29,6 +30,7 @@ const masterList = new Map([
 	[AmazonDe.name, AmazonDe],
 	[AmazonNl.name, AmazonNl],
 	[Asus.name, Asus],
+	[AsusDe.name, AsusDe],
 	[BAndH.name, BAndH],
 	[BestBuy.name, BestBuy],
 	[BestBuyCa.name, BestBuyCa],
@@ -51,7 +53,7 @@ for (const name of Config.store.stores) {
 	if (masterList.has(name)) {
 		list.set(name, masterList.get(name));
 	} else {
-		const logString = `No store named ${name}, skipping.`;
+		const logString = ` ${name}, skipping.`;
 		Logger.warn(logString);
 	}
 }


### PR DESCRIPTION
### Description

Closes #412 and #435 

### Testing
tested the german asus webstore with ASUS ROG-STRIX-RTX2060S-O8G-EVO-V2-GAMING and worked like it should.