### PR TITLE
feat: add `meta` to logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Here is a list of variables that you can use to customize your newly copied `.en
 | Environment variable | Description | Notes |
 |:---:|---|---|
 | `BROWSER_TRUSTED` | Skip Chromium Sandbox | Useful for containerized environments, default: `false` |
+| `COUNTRY` | [Supported country](#supported-countries) you want to be scraped | Currently only used by Nvidia, default: `usa` |
 | `DESKTOP_NOTIFICATIONS` | Display desktop notifications using [node-notifier](https://www.npmjs.com/package/node-notifier) | Default: `false` |
 | `DISCORD_NOTIFY_GROUP` | Discord group you would like to notify | Can be comma separated, use role ID, E.g.: `<@2834729847239842>` |
 | `DISCORD_WEB_HOOK` | Discord Web Hook URL | Can be comma separated, use whole webhook URL |
@@ -79,6 +80,7 @@ Here is a list of variables that you can use to customize your newly copied `.en
 | `IN_STOCK_WAIT_TIME` | Time to wait between requests to the same link if it has that card in stock | In seconds, default: `0` |
 | `LOG_LEVEL` | [Logging levels](https://github.com/winstonjs/winston#logging-levels) | Debugging related, default: `info` |
 | `LOW_BANDWIDTH` | Blocks images/fonts to reduce traffic | Disables ad blocker, default: `false` |
+| `MAX_PRICE` | Maximum price allowed for a match, applies to all cards (does not apply to these sites: Nvidia, Asus, EVGA) | Default: leave empty for no limit, otherwise enter a price (enter whole dollar amounts only, avoid use of: dollar symbols, commas, and periods.) e.g.: `1234` - Cards above `1234` will be skipped. |
 | `MICROCENTER_LOCATION` | Specific MicroCenter location to search | Default : `web` |
 | `NVIDIA_ADD_TO_CART_ATTEMPTS` | The maximum number of times the `nvidia-api` add to cart feature will be attempted before failing | Default: `10` |
 | `NVIDIA_SESSION_TTL` | The time in milliseconds to keep the cart active while using `nvidia-api` | Default: `60000` |
@@ -104,8 +106,6 @@ Here is a list of variables that you can use to customize your newly copied `.en
 | `SLACK_CHANNEL` | Slack channel for posting | E.g.: `update`, no need for `#` |
 | `SLACK_TOKEN` | Slack API token | |
 | `STORES` | [Supported stores](#supported-stores) you want to be scraped | Comma separated, default: `nvidia` |
-| `MAX_PRICE` | Maximum price allowed for a match, applies to all cards (does not apply to these sites: Nvidia, Asus, EVGA) | Default: leave empty for no limit, otherwise enter a price (enter whole dollar amounts only, avoid use of: dollar symbols, commas, and periods.) e.g.: `1234` - Cards above `1234` will be skipped. |
-| `COUNTRY` | [Supported country](#supported-countries) you want to be scraped | Currently only used by Nvidia, default: `usa` |
 | `SCREENSHOT` | Capture screenshot of page if a card is found | Default: `true` |
 | `TELEGRAM_ACCESS_TOKEN` | Telegram access token | |
 | `TELEGRAM_CHAT_ID` | Telegram chat ID | |

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,8 @@ async function main() {
 
 	const promises = [];
 	for (const store of Stores) {
-		Logger.debug(store.links);
+		Logger.debug('store links', {meta: {links: store.links}});
+
 		if (store.setupAction !== undefined) {
 			store.setupAction(browser);
 		}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,24 +1,28 @@
 import {Link, Store} from './store/model';
-import winston, {format} from 'winston';
 import {Config} from './config';
 import chalk from 'chalk';
+import winston from 'winston';
 
-const prettyJson = format.printf(info => {
+const prettyJson = winston.format.printf(info => {
 	const timestamp = new Date().toLocaleTimeString();
 
 	if (typeof info.message === 'object') {
 		info.message = JSON.stringify(info.message, null, 4);
 	}
 
+	if (info.meta) {
+		return chalk.grey(`[${timestamp}]`) + ` ${info.level} ` + chalk.grey('::') + ` ${info.message} ${chalk.magenta(JSON.stringify(info.meta, null, 2))}`;
+	}
+
 	return chalk.grey(`[${timestamp}]`) + ` ${info.level} ` + chalk.grey('::') + ` ${info.message}`;
 });
 
 export const Logger = winston.createLogger({
-	format: format.combine(
-		format.colorize(),
-		format.prettyPrint(),
-		format.splat(),
-		format.simple(),
+	format: winston.format.combine(
+		winston.format.colorize(),
+		winston.format.prettyPrint(),
+		winston.format.splat(),
+		winston.format.simple(),
 		prettyJson
 	),
 	level: Config.logLevel,


### PR DESCRIPTION
### Description

Adds `meta` to logger so that we can add extra meta info and format it correctly.

We should also include `error` in the future.