### PR TITLE
feat: Add amazon-uk store with 3080 cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Here is a list of variables that you can use to customize your newly copied `.en
 | Amazon (CA) | `amazon-ca`|
 | Amazon (DE) | `amazon-de`|
 | Amazon (NL) | `amazon-nl`|
+| Amazon (UK) | `amazon-uk`|
 | ASUS | `asus` |
 | B&H | `bandh`|
 | Best Buy | `bestbuy`|

--- a/src/store/model/amazon-uk.ts
+++ b/src/store/model/amazon-uk.ts
@@ -1,6 +1,4 @@
-import {Link, Store} from './store';
-import {logger} from '../../logger';
-import {parseCard} from './helpers/card';
+import {Store} from './store';
 
 export const AmazonUk: Store = {
 	backoffStatusCodes: [403, 429, 503],

--- a/src/store/model/amazon-uk.ts
+++ b/src/store/model/amazon-uk.ts
@@ -34,62 +34,91 @@ export const AmazonUk: Store = {
 			model: 'test:model',
 			series: 'test:series',
 			url: 'https://www.amazon.co.uk/dp/B081265T5Z/'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HN37VQK'
+		},
+		{
+			brand: 'asus',
+			model: 'tuf oc',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HN4DSTC'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3 ultra',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HGYXP4C'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 ultra',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HJ9XFNM'
+		},
+		{
+			brand: 'evga',
+			model: 'ftw3',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HGBYWQ6'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HGLN78Q'
+		},
+		{
+			brand: 'evga',
+			model: 'xc3 black',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HH1BMQQ'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'gaming oc',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HLZXHZY'
+		},
+		{
+			brand: 'gigabyte',
+			model: 'eagle oc',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HHZVZ3N'
+		},
+		{
+			brand: 'msi',
+			model: 'gaming x trio',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HM4V2DH'
+		},
+		{
+			brand: 'msi',
+			model: 'ventus 3x oc',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HM4M621'
+		},
+		{
+			brand: 'pny',
+			model: 'xlr8',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HBTJMLJ'
+		},
+		{
+			brand: 'pny',
+			model: 'xlr8-rgb',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HBR7QBM'
+		},
+		{
+			brand: 'zotac',
+			model: 'trinity',
+			series: '3080',
+			url: 'https://www.amazon.co.uk/dp/B08HR1NPPQ'
 		}
 	],
-	linksBuilder: {
-		builder: (docElement, series) => {
-			const productElements = docElement.find('.s-result-list .s-result-item[data-asin]');
-			const links: Link[] = [];
-			for (let i = 0; i < productElements.length; i++) {
-				const productElement = productElements.eq(i);
-				const asin = productElement.attr()['data-asin'];
-
-				if (!asin) {
-					continue;
-				}
-
-				const url = `https://www.amazon.co.uk/dp/${asin}/`;
-				const titleElement = productElement.find('.sg-col-inner h2 a.a-text-normal[href] span').first();
-				const title = titleElement.text().trim();
-
-				if (!title || !new RegExp(`RTX ?${series}`, 'i').exec(title)) {
-					continue;
-				}
-
-				const card = parseCard(title);
-
-				if (card) {
-					links.push({
-						brand: card.brand as any,
-						cartUrl: `https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=${asin}&Quantity.1=1`,
-						model: card.model,
-						series,
-						url
-					});
-				} else {
-					logger.error(`Failed to parse card: ${title}`);
-				}
-			}
-
-			return links;
-		},
-		ttl: 300000,
-		urls: [
-			{
-				series: '3080',
-				url: [
-					'https://www.amazon.co.uk/s?k=%2B%22RTX+3080%22+-2080+-GTX&i=computers&rh=n%3A430500031%2Cp_n_availability%3A419162031&s=relevancerank&dc&qid=1601675291',
-					'https://www.amazon.co.uk/s?k=%2B%22RTX+3080%22+-2080+-GTX&i=computers&rh=n%3A430500031%2Cp_n_availability%3A419162031&s=relevancerank&dc&qid=1601675594&page=2'
-				]
-			},
-			{
-				series: '3090',
-				url: [
-					'https://www.amazon.co.uk/s?k=%2B%22RTX+3090%22+-3080+-GTX&i=computers&rh=n%3A430500031%2Cp_n_availability%3A419162031&s=relevancerank&dc&qid=1601675291',
-					'https://www.amazon.co.uk/s?k=%2B%22RTX+3090%22+-3080+-GTX&i=computers&rh=n%3A430500031%2Cp_n_availability%3A419162031&s=relevancerank&dc&qid=1601675594&page=2'
-				]
-			}
-		]
-	},
 	name: 'amazon-uk'
 };

--- a/src/store/model/amazon-uk.ts
+++ b/src/store/model/amazon-uk.ts
@@ -1,0 +1,95 @@
+import {Link, Store} from './store';
+import {logger} from '../../logger';
+import {parseCard} from './helpers/card';
+
+export const AmazonUk: Store = {
+	backoffStatusCodes: [403, 429, 503],
+	labels: {
+		captcha: {
+			container: 'body',
+			text: ['enter the characters you see below']
+		},
+		inStock: {
+			container: '#availability',
+			text: ['in stock']
+		},
+		maxPrice: {
+			container: 'span[class*="PriceString"]'
+		},
+		outOfStock: [
+			{
+				container: '#availability',
+				text: ['out of stock', 'unavailable']
+			},
+			{
+				container: '#backInStock',
+				text: ['unavailable']
+			}
+		]
+	},
+	links: [
+		{
+			brand: 'test:brand',
+			cartUrl: 'https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=B081265T5Z&Quantity.1=1',
+			model: 'test:model',
+			series: 'test:series',
+			url: 'https://www.amazon.co.uk/dp/B081265T5Z/'
+		}
+	],
+	linksBuilder: {
+		builder: (docElement, series) => {
+			const productElements = docElement.find('.s-result-list .s-result-item[data-asin]');
+			const links: Link[] = [];
+			for (let i = 0; i < productElements.length; i++) {
+				const productElement = productElements.eq(i);
+				const asin = productElement.attr()['data-asin'];
+
+				if (!asin) {
+					continue;
+				}
+
+				const url = `https://www.amazon.co.uk/dp/${asin}/`;
+				const titleElement = productElement.find('.sg-col-inner h2 a.a-text-normal[href] span').first();
+				const title = titleElement.text().trim();
+
+				if (!title || !new RegExp(`RTX ?${series}`, 'i').exec(title)) {
+					continue;
+				}
+
+				const card = parseCard(title);
+
+				if (card) {
+					links.push({
+						brand: card.brand as any,
+						cartUrl: `https://www.amazon.co.uk/gp/aws/cart/add.html?ASIN.1=${asin}&Quantity.1=1`,
+						model: card.model,
+						series,
+						url
+					});
+				} else {
+					logger.error(`Failed to parse card: ${title}`);
+				}
+			}
+
+			return links;
+		},
+		ttl: 300000,
+		urls: [
+			{
+				series: '3080',
+				url: [
+					'https://www.amazon.co.uk/s?k=%2B%22RTX+3080%22+-2080+-GTX&i=computers&rh=n%3A430500031%2Cp_n_availability%3A419162031&s=relevancerank&dc&qid=1601675291',
+					'https://www.amazon.co.uk/s?k=%2B%22RTX+3080%22+-2080+-GTX&i=computers&rh=n%3A430500031%2Cp_n_availability%3A419162031&s=relevancerank&dc&qid=1601675594&page=2'
+				]
+			},
+			{
+				series: '3090',
+				url: [
+					'https://www.amazon.co.uk/s?k=%2B%22RTX+3090%22+-3080+-GTX&i=computers&rh=n%3A430500031%2Cp_n_availability%3A419162031&s=relevancerank&dc&qid=1601675291',
+					'https://www.amazon.co.uk/s?k=%2B%22RTX+3090%22+-3080+-GTX&i=computers&rh=n%3A430500031%2Cp_n_availability%3A419162031&s=relevancerank&dc&qid=1601675594&page=2'
+				]
+			}
+		]
+	},
+	name: 'amazon-uk'
+};

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -3,6 +3,7 @@ import {Amazon} from './amazon';
 import {AmazonCa} from './amazon-ca';
 import {AmazonDe} from './amazon-de';
 import {AmazonNl} from './amazon-nl';
+import {AmazonUk} from './amazon-uk';
 import {Asus} from './asus';
 import {AsusDe} from './asus-de';
 import {BAndH} from './bandh';
@@ -29,6 +30,7 @@ const masterList = new Map([
 	[AmazonCa.name, AmazonCa],
 	[AmazonDe.name, AmazonDe],
 	[AmazonNl.name, AmazonNl],
+	[AmazonUk.name, AmazonUk],
 	[Asus.name, Asus],
 	[AsusDe.name, AsusDe],
 	[BAndH.name, BAndH],


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Fixes #357 

I tried to base this on @andrewmackrodt's branch but he added a new function for getting new cards (see https://github.com/jef/nvidia-snatcher/compare/main...andrewmackrodt:develop#diff-f41e9d04a45c83f3b6f6e630f10117fe) so I ended up basing it on the Amazon-DE store.

Definitely inspired by hacktoberfest 🎃

### Testing

* I ran `npm run lint` and it passed the linter
* I edited my `.env` to use `STORES="amazon-uk"`
* I ran the bot with `npm run start:dev` and it seemed to be working!
