### PR TITLE
feat: framework updates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import {Stores} from './store/model';
 import {adBlocker} from './adblocker';
 import {config} from './config';
-import {fetchLinks} from './store/fetch-links';
 import {getSleepTime} from './util';
 import {logger} from './logger';
 import puppeteer from 'puppeteer-extra';
@@ -50,21 +49,14 @@ async function main() {
 		headless: config.browser.isHeadless
 	});
 
-	const promises = [];
 	for (const store of Stores) {
 		logger.debug('store links', {meta: {links: store.links}});
 		if (store.setupAction !== undefined) {
 			store.setupAction(browser);
 		}
 
-		if (store.linksBuilder) {
-			promises.push(fetchLinks(store, browser));
-		}
-
 		setTimeout(tryLookupAndLoop, getSleepTime(), browser, store);
 	}
-
-	await Promise.all(promises);
 }
 
 /**

--- a/src/store/fetch-links.ts
+++ b/src/store/fetch-links.ts
@@ -30,16 +30,20 @@ export async function fetchLinks(store: Store, browser: Browser) {
 		return;
 	}
 
-	const promises = [];
+	const promises: Array<Promise<void>> = [];
 
-	for (const {series, url} of store.linksBuilder.urls) {
+	for (let {series, url} of store.linksBuilder.urls) {
 		if (!filterSeries(series)) {
 			continue;
 		}
 
 		logger.info(Print.message('DETECTING STORE LINKS', series, store, true));
 
-		promises.push(usingResponse(browser, url, async response => {
+		if (!Array.isArray(url)) {
+			url = [url];
+		}
+
+		url.map(x => promises.push(usingResponse(browser, x, async response => {
 			const text = await response?.text();
 
 			if (!text) {
@@ -51,7 +55,7 @@ export async function fetchLinks(store: Store, browser: Browser) {
 			const links = store.linksBuilder!.builder(docElement, series);
 
 			addNewLinks(store, links, series);
-		}));
+		})));
 	}
 
 	await Promise.all(promises);

--- a/src/store/fetch-links.ts
+++ b/src/store/fetch-links.ts
@@ -7,7 +7,7 @@ import {usingResponse} from '../util';
 
 function addNewLinks(store: Store, links: Link[], series: Series) {
 	if (links.length === 0) {
-		logger.error(Print.message('NO STORE LINKS FOUND', series, store, true));
+		logger.warn(Print.message('NO STORE LINKS FOUND', series, store, true));
 
 		return;
 	}
@@ -37,7 +37,7 @@ export async function fetchLinks(store: Store, browser: Browser) {
 			continue;
 		}
 
-		logger.info(Print.message('DETECTING STORE LINKS', series, store, true));
+		logger.debug(Print.message('DETECTING STORE LINKS', series, store, true));
 
 		if (!Array.isArray(url)) {
 			url = [url];

--- a/src/store/model/helpers/card.ts
+++ b/src/store/model/helpers/card.ts
@@ -72,10 +72,20 @@ export function getProductLinksBuilder(options: LinksBuilderOptions) {
 }
 
 export function parseCard(name: string): Card | null {
-	name = name.replace(/[^\w ]+/g, '').trim();
-	name = name.replace(/\bgraphics card\b/gi, '').trim();
-	name = name.replace(/\b\w+ fan\b/gi, '').trim();
-	name = name.replace(/\s{2,}/g, ' ');
+	name = name.replace(/\w+-\w+-[^ ]+/g, '');
+	name = name.replace(/\([^(]*\)/g, '');
+	name = name.replace(/, .+$/, '');
+	name = name.replace(/ with .+$/, '');
+
+	// Account for incorrect titles, e.g. MSIGeforce
+	name = name.replace(/geforce/i, '');
+
+	name = name.replace(/[^\w ]+/g, '');
+	name = name.replace(/\bgraphics card\b/gi, '');
+	name = name.replace(/\b(?<!founders) edition\b/gi, '');
+	name = name.replace(/\b(series )?bundle\b/gi, '');
+	name = name.replace(/\b\w+ fan\b/gi, '');
+	name = name.replace(/\s{2,}/g, ' ').trim();
 
 	let model = name.split(' ');
 	const brand = model.shift();
@@ -83,6 +93,9 @@ export function parseCard(name: string): Card | null {
 	if (!brand) {
 		return null;
 	}
+
+	// Split non spaced TitleCase words only after extracting brand
+	model = model.join(' ').replace(/([A-Z][a-z]+)([A-Z][a-z]+)/g, '$1 $2').split(' ');
 
 	// Some vendors have oc at the beginning of the product name,
 	// store whether the card contains the term "oc" and remove
@@ -96,8 +109,9 @@ export function parseCard(name: string): Card | null {
 			return false;
 		}
 
-		return !word.match(/^(nvidia|geforce|rtx|amp[ae]re|graphics|card|gpu|pci-?e(xpress)?|ray-?tracing|ray|tracing|core|boost)$/i) &&
-			!word.match(/^(\d+(?:gb?|mhz)?|gb|mhz|g?ddr(\d+x?)?)$/i);
+		return !word.match(/^(nvidia|geforce|ge|force|rtx|amp[ae]re|graphics|card|gpu|pci-?e(xpress)?|ray-?tracing|ray|tracing|core|boost|epicx)$/i) &&
+			!word.match(/^(\d+(?:gb?|mhz)?|gb|mhz|g?ddr(\d+x?)?)$/i) &&
+			!word.match(/^(display ?port|hdmi|vga)$/i);
 	});
 	/* eslint-enable @typescript-eslint/prefer-regexp-exec */
 

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -47,7 +47,7 @@ export type Store = {
 	linksBuilder?: {
 		builder: (docElement: cheerio.Cheerio, series: Series) => Link[];
 		ttl?: number;
-		urls: Array<{series: Series; url: string}>;
+		urls: Array<{series: Series; url: string | string[]}>;
 	};
 	labels: Labels;
 	name: string;

--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -46,6 +46,7 @@ export type Store = {
 	links: Link[];
 	linksBuilder?: {
 		builder: (docElement: cheerio.Cheerio, series: Series) => Link[];
+		ttl?: number;
 		urls: Array<{series: Series; url: string}>;
 	};
 	labels: Labels;


### PR DESCRIPTION
**Relates to #455 - merge first**

I began the concept of a `linksBuilder` in #270, this allows us to detect links for a store without having to maintain a hardcoded list of URLs. This expands upon the part of work by introducing an optional `ttl` (the time in milliseconds to check for new links), adds a generic helper method to extract links from several stores, and updates the helper method to parse a card's store title into our model and brand names. For an example of why this is useful, see the huge number of listings Amazon have: https://github.com/jef/nvidia-snatcher/issues/357#issuecomment-703589117.