### PR TITLE
feat: allow multiple microcenter locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Here is a list of variables that you can use to customize your newly copied `.en
 | `MAX_PRICE_SERIES_3070` | Maximum price allowed for a match, applies 3070 series cards (does not apply to these sites: Nvidia, Asus, EVGA) | Default: leave empty for no limit, otherwise enter a price (enter whole dollar amounts only, avoid use of: dollar symbols, commas, and periods.) e.g.: `1234` - Cards above `1234` will be skipped. |
 | `MAX_PRICE_SERIES_3080` | Maximum price allowed for a match, applies 3080 series cards (does not apply to these sites: Nvidia, Asus, EVGA) | Default: leave empty for no limit, otherwise enter a price (enter whole dollar amounts only, avoid use of: dollar symbols, commas, and periods.) e.g.: `1234` - Cards above `1234` will be skipped. |
 | `MAX_PRICE_SERIES_3090` | Maximum price allowed for a match, applies 3090 series cards (does not apply to these sites: Nvidia, Asus, EVGA) | Default: leave empty for no limit, otherwise enter a price (enter whole dollar amounts only, avoid use of: dollar symbols, commas, and periods.) e.g.: `1234` - Cards above `1234` will be skipped. |
-| `MICROCENTER_LOCATION` | Specific MicroCenter location to search | Default : `web` |
+| `MICROCENTER_LOCATION` | Specific MicroCenter location(s) to search | Comma separated, e.g.: `marietta,duluth` |
 | `NVIDIA_ADD_TO_CART_ATTEMPTS` | The maximum number of times the `nvidia-api` add to cart feature will be attempted before failing | Default: `10` |
 | `NVIDIA_SESSION_TTL` | The time in milliseconds to keep the cart active while using `nvidia-api` | Default: `60000` |
 | `OPEN_BROWSER` | Toggle for whether or not the browser should open when item is found | Default: `true` |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Here is a list of variables that you can use to customize your newly copied `.en
 | `MAX_PRICE_SERIES_3070` | Maximum price allowed for a match, applies 3070 series cards (does not apply to these sites: Nvidia, Asus, EVGA) | Default: leave empty for no limit, otherwise enter a price (enter whole dollar amounts only, avoid use of: dollar symbols, commas, and periods.) e.g.: `1234` - Cards above `1234` will be skipped. |
 | `MAX_PRICE_SERIES_3080` | Maximum price allowed for a match, applies 3080 series cards (does not apply to these sites: Nvidia, Asus, EVGA) | Default: leave empty for no limit, otherwise enter a price (enter whole dollar amounts only, avoid use of: dollar symbols, commas, and periods.) e.g.: `1234` - Cards above `1234` will be skipped. |
 | `MAX_PRICE_SERIES_3090` | Maximum price allowed for a match, applies 3090 series cards (does not apply to these sites: Nvidia, Asus, EVGA) | Default: leave empty for no limit, otherwise enter a price (enter whole dollar amounts only, avoid use of: dollar symbols, commas, and periods.) e.g.: `1234` - Cards above `1234` will be skipped. |
-| `MICROCENTER_LOCATION` | Specific MicroCenter location(s) to search | Comma separated, e.g.: `marietta,duluth` |
+| `MICROCENTER_LOCATION` | Specific MicroCenter location(s) to search | Comma separated, e.g.: `marietta,duluth`, default: `web` |
 | `NVIDIA_ADD_TO_CART_ATTEMPTS` | The maximum number of times the `nvidia-api` add to cart feature will be attempted before failing | Default: `10` |
 | `NVIDIA_SESSION_TTL` | The time in milliseconds to keep the cart active while using `nvidia-api` | Default: `60000` |
 | `OPEN_BROWSER` | Toggle for whether or not the browser should open when item is found | Default: `true` |

--- a/src/config.ts
+++ b/src/config.ts
@@ -218,7 +218,7 @@ const store = {
 			3090: envOrNumber(process.env.MAX_PRICE_3090)
 		}
 	},
-	microCenterLocation: envOrString(process.env.MICROCENTER_LOCATION, 'web'),
+	microCenterLocation: envOrArray(process.env.MICROCENTER_LOCATION, ['web']),
 	showOnlyBrands: envOrArray(process.env.SHOW_ONLY_BRANDS),
 	showOnlyModels: envOrArray(process.env.SHOW_ONLY_MODELS),
 	showOnlySeries: envOrArray(process.env.SHOW_ONLY_SERIES, ['3070', '3080', '3090']),

--- a/src/store/model/microcenter.ts
+++ b/src/store/model/microcenter.ts
@@ -1,7 +1,8 @@
-import {Store} from './store';
+import {Link, Store} from './store';
 import {config} from '../../config';
+import {logger} from '../../logger';
 
-const microCenterLocation = config.store.microCenterLocation;
+const microCenterLocations = config.store.microCenterLocation;
 
 const microCenterLocationToId: Map<string, string> = new Map([
 	['web', '029'],
@@ -32,11 +33,65 @@ const microCenterLocationToId: Map<string, string> = new Map([
 	['yonkers', '105']
 ]);
 
+let links: Link[] = [];
 let storeId: string;
-if (microCenterLocationToId.get(microCenterLocation) === undefined) {
-	storeId = '029';
-} else {
-	storeId = microCenterLocationToId.get(microCenterLocation)!;
+for (const microCenterLocation of microCenterLocations) {
+	if (microCenterLocationToId.get(microCenterLocation) === undefined) {
+		const logString = `No MicroCenter location named ${microCenterLocation}, skipping.`;
+		logger.warn(logString);
+	} else {
+		storeId = microCenterLocationToId.get(microCenterLocation)!;
+		links = links.concat([
+			{
+				brand: 'test:brand',
+				model: 'test:model',
+				series: 'test:series',
+				url: `https://www.microcenter.com/product/618433/evga-geforce-rtx-2060-ko-ultra-overclocked-dual-fan-6gb-gddr6-pcie-30-graphics-card/?storeid=${storeId}`
+			},
+			{
+				brand: 'evga',
+				model: 'xc3 ultra',
+				series: '3080',
+				url: `https://www.microcenter.com/product/628344/evga-geforce-rtx-3080-xc3-ultra-gaming-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
+			},
+			{
+				brand: 'evga',
+				model: 'ftw3 ultra',
+				series: '3080',
+				url: `https://www.microcenter.com/product/628346/evga-geforce-rtx-3080-ftw3-ultra-gaming-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
+			},
+			{
+				brand: 'msi',
+				model: 'ventus 3x',
+				series: '3080',
+				url: `https://www.microcenter.com/product/628331/msi-geforce-rtx-3080-ventus-3x-overclocked-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
+			},
+			{
+				brand: 'asus',
+				model: 'tuf',
+				series: '3080',
+				url: `https://www.microcenter.com/product/628303/asus-geforce-rtx-3080-tuf-gaming-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
+			},
+			{
+				brand: 'msi',
+				model: 'gaming x trio',
+				series: '3080',
+				url: `https://www.microcenter.com/product/628330/msi-geforce-rtx-3080-gaming-x-trio-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
+			},
+			{
+				brand: 'evga',
+				model: 'xc3 black',
+				series: '3080',
+				url: `https://www.microcenter.com/product/628340/evga-geforce-rtx-3080-xc3-black-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
+			},
+			{
+				brand: 'zotac',
+				model: 'trinity',
+				series: '3080',
+				url: `https://www.microcenter.com/product/628607/zotac-geforce-rtx-3080-trinity-overclocked-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
+			}
+		]);
+	}
 }
 
 export const MicroCenter: Store = {
@@ -50,55 +105,6 @@ export const MicroCenter: Store = {
 			euroFormat: false
 		}
 	},
-	links: [
-		{
-			brand: 'test:brand',
-			model: 'test:model',
-			series: 'test:series',
-			url: `https://www.microcenter.com/product/618433/evga-geforce-rtx-2060-ko-ultra-overclocked-dual-fan-6gb-gddr6-pcie-30-graphics-card/?storeid=${storeId}`
-		},
-		{
-			brand: 'evga',
-			model: 'xc3 ultra',
-			series: '3080',
-			url: `https://www.microcenter.com/product/628344/evga-geforce-rtx-3080-xc3-ultra-gaming-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
-		},
-		{
-			brand: 'evga',
-			model: 'ftw3 ultra',
-			series: '3080',
-			url: `https://www.microcenter.com/product/628346/evga-geforce-rtx-3080-ftw3-ultra-gaming-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
-		},
-		{
-			brand: 'msi',
-			model: 'ventus 3x',
-			series: '3080',
-			url: `https://www.microcenter.com/product/628331/msi-geforce-rtx-3080-ventus-3x-overclocked-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
-		},
-		{
-			brand: 'asus',
-			model: 'tuf',
-			series: '3080',
-			url: `https://www.microcenter.com/product/628303/asus-geforce-rtx-3080-tuf-gaming-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
-		},
-		{
-			brand: 'msi',
-			model: 'gaming x trio',
-			series: '3080',
-			url: `https://www.microcenter.com/product/628330/msi-geforce-rtx-3080-gaming-x-trio-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
-		},
-		{
-			brand: 'evga',
-			model: 'xc3 black',
-			series: '3080',
-			url: `https://www.microcenter.com/product/628340/evga-geforce-rtx-3080-xc3-black-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
-		},
-		{
-			brand: 'zotac',
-			model: 'trinity',
-			series: '3080',
-			url: `https://www.microcenter.com/product/628607/zotac-geforce-rtx-3080-trinity-overclocked-triple-fan-10gb-gddr6x-pcie-40-graphics-card/?storeid=${storeId}`
-		}
-	],
+	links,
 	name: 'microcenter'
 };


### PR DESCRIPTION
### Description

Resolves #386 

In some cases (e.g. Georgia) there are more than one MicroCenter locations nearby, so we'd want to check more than one location.

### Testing

Set MICROCENTER_LOCATION variable to "duluth,marietta" and STORES to "microcenter". Verified in the debug logs that links from both locations were loaded into the Store object for MicroCenter. The bot then checked for cards from MicroCenter successfully.
