### PR TITLE
fix: add support for stores label text to have uppercase letters

### DIFF
--- a/src/store/includes-labels.ts
+++ b/src/store/includes-labels.ts
@@ -86,7 +86,7 @@ export async function extractPageContents(page: Page, selector: Selector): Promi
  */
 export function includesLabels(domText: string, searchLabels: string[]): boolean {
 	const domTextLowerCase = domText.toLowerCase();
-	return searchLabels.some(label => domTextLowerCase.includes(label));
+	return searchLabels.some(label => domTextLowerCase.includes(label.toLowerCase()));
 }
 
 export async function cardPrice(page: Page, query: Pricing, max: number, options: Selector) {


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
Currently the labels text to be searched must only be in lowercase for the search in DOM text to work successfully. If the provided labels text has uppercase letters, it will not be matched successfully. 

Some contributors might not know about this restriction and may set text containing uppercase letters.

With this commit, It should be possible to have uppercase letters in the labels text. This change should be backwards compatible, and should work for both cases with labels having lower case letters or upper case letters.


![1](https://user-images.githubusercontent.com/6310379/96163754-93501f00-0f1a-11eb-9710-cfafd4d6dba9.PNG)

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

<!-- Feel free to include your Discord tag here and we'll consider making you a ringer! -->
<!-- Continuous improvements may also grant you contributor access. -->

### Testing
If you set some label text that contains any uppercase letter, it will not be found in the DOM text because the DOM text is being lowercased before search and match while the label text is not lowercased. With this change we lowercase the label text too before performing search and match, hence both uppercase letters and lowercase letters work fine.


<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

