### PR TITLE
The Gigabyte "vision" model should be "vision oc"  when filtering by model

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Here is a list of variables that you can use to customize your newly copied `.en
 |:---:|---|
 | `asus` | `rog strix`, `rog strix oc`, `strix`, `tuf`, `tuf oc` |
 | `evga` | `ftw3`, `ftw3 ultra`, `xc3 black`, `xc3`, `xc3 ultra` |
-| `gigabyte` | `aorus master`, `eagle`, `eagle oc`, `gaming`, `gaming oc`, `vision` |
+| `gigabyte` | `aorus master`, `eagle`, `eagle oc`, `gaming`, `gaming oc`, `vision oc` |
 | `msi` | `gaming x trio`, `ventus 3x`, `ventus 3x oc` |
 | `nvidia` | `founders edition` |
 | `pny` | `dual fan`, `xlr8`, `xlr8 rgb` |


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

<!-- Please also include relevant motivation and context. -->
Purely an informational change for anyone looking to filter by Gigabyte's Vision OC card. Following the readme's filter guide for this model results in a filter for a card that doesn't exist.

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
Running this while filtering by `gigabyte` brand results in searches for `vision oc` cards (along with other Gigabyte cards, as expected), but filtering by the `vision` model like the readme says doesn't result in any searches. Filtering by the `vision oc` model works as expected.
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
