### PR TITLE
feat(store): add ttl for `scan`

### DIFF
--- a/src/store/model/scan.ts
+++ b/src/store/model/scan.ts
@@ -32,6 +32,7 @@ export const Scan: Store = {
 			titleSelector: '.details .description',
 			urlSelector: 'a[href]'
 		}),
+		ttl: 300000,
 		urls: [
 			{
 				series: '3070',


### PR DESCRIPTION
### Description

Add a ttl to refresh scan store links every 5m. This is due to the founders card links being intermittently available. Currently the page is 404 but it was active yesterday when the cards went up. Credit to andrew on discord for the suggestion.

https://www.scan.co.uk/shops/nvidia/3090-founders-edition

### Testing

Tested running snatcher locally with Scan enabled.

### New dependencies

None.
