### PR TITLE
docs: readme install instructions typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You do not need any computer skills, smarts, or anything of that nature. You are
 - [git](https://git-scm.com/)
 - Clone this project `git clone https://github.com/jef/nvidia-snatcher.git`
 - Run `npm install`
-- Copy `.env.example` to a new file `.env` and edit the `.env` file to your liking using your [favorite text editor](https://code.visualstudio.com/)
+- Copy `.env-example` to a new file `.env` and edit the `.env` file to your liking using your [favorite text editor](https://code.visualstudio.com/)
     - More on this in [customization](#Customization)
 - Run `npm run start` to start
 


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

The [native installation instructions](https://github.com/jef/nvidia-snatcher#native-installation) in the readme have `.env.example` as the name of the example env file, where the file is actually called `.env-example`. This PR updates this section of the readme to use the correct filename.

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

<!-- Feel free to include your Discord tag here and we'll consider making you a ringer! -->
<!-- Continuous improvements may also grant you contributor access. -->

### Testing
N/A
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies
N/A
<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
