### PR TITLE
fix: sleep between lookups

### DIFF
--- a/src/store/model/store.ts
+++ b/src/store/model/store.ts
@@ -60,6 +60,9 @@ export type Store = {
 	 */
 	successStatusCodes?: StatusCodeRangeArray;
 	waitUntil?: LoadEvent;
-	minPageSleep?: number;
-	maxPageSleep?: number;
+	storeData?: {
+		minPageSleep?: number;
+		maxPageSleep?: number;
+		name?: string;
+	};
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,8 +5,14 @@ import {disableBlockerInPage} from './adblocker';
 import {logger} from './logger';
 
 export function getSleepTime(store: Store) {
-	const minSleep = store.minPageSleep as number;
-	return minSleep + (Math.random() * ((store.maxPageSleep as number) - minSleep));
+	let minSleep = config.browser.minSleep;
+	let maxSleep = config.browser.maxSleep;
+	if (store.storeData) {
+		minSleep = store.storeData.minPageSleep as number;
+		maxSleep = store.storeData.maxPageSleep as number;
+	}
+
+	return minSleep + (Math.random() * (maxSleep - minSleep));
 }
 
 export async function delay(ms: number) {


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

Sleep between lookups wasn't working, instead lookups happened continously.

This happened because min and max sleep time where read from the wrong place, resulting in NaN values, resulting in 0ms sleep.

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

<!-- Feel free to include your Discord tag here and we'll consider making you a ringer! -->
<!-- Continuous improvements may also grant you contributor access. -->

### Testing

Ran the snatcher itself as well as notification test, with custom PAGE_SLEEP_MIN and PAGE_SLEEP_MAX set, as well as 'store specific' sleep time set:
```
SHOW_ONLY_MODELS=founders edition
SHOW_ONLY_SERIES=3080
PAGE_SLEEP_MIN=60000
PAGE_SLEEP_MAX=120000
STORES=notebooksbilliger,nvidia:5000:10000
```

Output and sleep behaviour is as expected:

```
[19:19:11] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:19:13] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:19:23] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:19:26] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:19:32] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:19:34] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:19:45] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:19:47] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:19:56] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:19:58] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:20:05] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:20:07] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:20:18] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:20:20] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:20:27] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:20:29] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:20:36] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:20:38] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:20:44] info :: ✖ [notebooksbilliger] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:20:44] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
[19:20:46] info :: ✖ [nvidia] [nvidia (3080)] founders edition :: OUT OF STOCK
```

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->