### PR TITLE
feat(store): add founders editions to notebooksbilliger.de

### DIFF
--- a/src/store/model/notebooksbilliger.ts
+++ b/src/store/model/notebooksbilliger.ts
@@ -31,6 +31,12 @@ export const Notebooksbilliger: Store = {
 			url: 'https://www.notebooksbilliger.de/gainward+geforce+rtx+2070+super+phoenix+v1+grafikkarte+656238'
 		},
 		{
+			brand: 'nvidia',
+			model: 'founders edition',
+			series: '3080',
+			url: 'https://www.notebooksbilliger.de/nvidia+geforce+rtx+3080+founders+edition+683301'
+		},
+		{
 			brand: 'gainward',
 			model: 'phoenix gs',
 			series: '3080',
@@ -89,6 +95,12 @@ export const Notebooksbilliger: Store = {
 			model: 'xlr8 rgb',
 			series: '3080',
 			url: 'https://www.notebooksbilliger.de/pny+geforce+rtx+3080+10gb+xlr8+gaming+revel+epic+x+grafikkarte+677412'
+		},
+		{
+			brand: 'nvidia',
+			model: 'founders edition',
+			series: '3090',
+			url: 'https://www.notebooksbilliger.de/nvidia+geforce+rtx+3090+founders+edition+683300'
 		},
 		{
 			brand: 'asus',


### PR DESCRIPTION
### Description
Notebooksbilliger seems to be the (official) retailer for german FE drops now.
Fixes #584 


