### PR TITLE
feat: allow filtering per model by a specific series

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Here is a list of variables that you can use to customize your newly copied `.en
 | `PUSHOVER_PRIORITY` | Pushover message priority |
 | `SCREENSHOT` | Capture screenshot of page if a card is found | Default: `true` |
 | `SHOW_ONLY_BRANDS` | Filter to show specified brands | Comma separated, e.g.: `evga,zotac` |
-| `SHOW_ONLY_MODELS` | Filter to show specified models | Comma separated, e.g.: `founders edition,rog strix` |
+| `SHOW_ONLY_MODELS` | Filter to show specified models | Both supported formats are comma separated <br/><br/>1. Standard  E.g.: `founders edition,rog strix` <br/><br/> 2. Advanced E.g: `MODEL:SERIES`, E.g: `founders edition:3090,rog strix` |
 | `SHOW_ONLY_SERIES` | Filter to show specified series | Comma separated, e.g.: `3080` |
 | `SLACK_CHANNEL` | Slack channel for posting | E.g.: `update`, no need for `#` |
 | `SLACK_TOKEN` | Slack API token | |

--- a/src/config.ts
+++ b/src/config.ts
@@ -243,7 +243,13 @@ const store = {
 	},
 	microCenterLocation: envOrArray(process.env.MICROCENTER_LOCATION, ['web']),
 	showOnlyBrands: envOrArray(process.env.SHOW_ONLY_BRANDS),
-	showOnlyModels: envOrArray(process.env.SHOW_ONLY_MODELS),
+	showOnlyModels: envOrArray(process.env.SHOW_ONLY_MODELS).map(entry => {
+		const [name, series] = entry.match(/[^:]+/g) ?? [];
+		return {
+			name: envOrString(name),
+			series: envOrString(series)
+		};
+	}),
 	showOnlySeries: envOrArray(process.env.SHOW_ONLY_SERIES, ['3070', '3080', '3090']),
 	stores: envOrArray(process.env.STORES, ['nvidia']).map(entry => {
 		const [name, minPageSleep, maxPageSleep] = entry.match(/[^:]+/g) ?? [];

--- a/src/store/filter.ts
+++ b/src/store/filter.ts
@@ -18,16 +18,22 @@ function filterBrand(brand: Link['brand']): boolean {
  * Returns true if the model should be checked for stock
  *
  * @param model The model of the GPU
+ * @param series The series of the GPU
  */
-function filterModel(model: Link['model']): boolean {
+function filterModel(model: Link['model'], series: Link['series']): boolean {
 	if (config.store.showOnlyModels.length === 0) {
 		return true;
 	}
 
 	const sanitizedModel = model.replace(/\s/g, '');
-	for (const configModel of config.store.showOnlyModels) {
-		const sanitizedConfigModel = configModel.replace(/\s/g, '');
-		if (sanitizedModel === sanitizedConfigModel) {
+	const sanitizedSeries = series.replace(/\s/g, '');
+	for (const configModelEntry of config.store.showOnlyModels) {
+		const sanitizedConfigModel = configModelEntry.name.replace(/\s/g, '');
+		const sanitizedConfigSeries = configModelEntry.series.replace(/\s/g, '');
+		if (sanitizedConfigSeries ?
+			sanitizedSeries === sanitizedConfigSeries && sanitizedModel === sanitizedConfigModel :
+			sanitizedModel === sanitizedConfigModel
+		) {
 			return true;
 		}
 	}
@@ -56,7 +62,7 @@ export function filterSeries(series: Link['series']): boolean {
 export function filterStoreLink(link: Link): boolean {
 	return (
 		filterBrand(link.brand) &&
-		filterModel(link.model) &&
+		filterModel(link.model, link.series) &&
 		filterSeries(link.series)
 	);
 }

--- a/src/store/model/index.ts
+++ b/src/store/model/index.ts
@@ -115,7 +115,9 @@ if (config.store.showOnlyBrands.length > 0) {
 }
 
 if (config.store.showOnlyModels.length > 0) {
-	logger.info(`ℹ selected models: ${config.store.showOnlyModels.join(', ')}`);
+	logger.info(`ℹ selected models: ${config.store.showOnlyModels.map(entry => {
+		return entry.series ? entry.name + ' (' + entry.series + ')' : entry.name;
+	}).join(', ')}`);
 }
 
 if (config.store.showOnlySeries.length > 0) {


### PR DESCRIPTION
<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description
Possibility to filter additionally a model by a series.

**Use-Case:**
Searching for 3 cards: the founders edition 3090, asus strix oc 3080 and 3090.
Both models are generally available for both series. (e.g founders edition 3080, founders edition 3090 etc.)

**Example Config for Use-Case:**
STORES="asus,nvidia"
SHOW_ONLY_BRANDS="asus, nvidia"
SHOW_ONLY_MODELS="rog strix oc, founders edition:3090"

Result:
nvidia-snatcher searches for: rog strix oc 3080, rog strix oc 3090, founders edition 3090

**Limitations**
Additional filtering only works for series that are globally enabled and not filtered out by SHOW_ONLY_SERIES.

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

<!-- Feel free to include your Discord tag here and we'll consider making you a ringer! -->
<!-- Continuous improvements may also grant you contributor access. -->

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
