### PR TITLE
feat: add series to Discord webhook

### DIFF
--- a/src/notification/discord.ts
+++ b/src/notification/discord.ts
@@ -18,6 +18,7 @@ export function sendDiscordMessage(link: Link, store: Store) {
 				embed.addField('URL', link.cartUrl ? link.cartUrl : link.url, true);
 				embed.addField('Store', store.name, true);
 				embed.addField('Brand', link.brand, true);
+				embed.addField('Series', link.series, true);
 				embed.addField('Model', link.model, true);
 
 				if (notifyGroup) {


### PR DESCRIPTION
### Description
Currently the Discord notification does not show whether the card in stock is a 3080 or 3090.

![image](https://user-images.githubusercontent.com/8883045/97425932-0db57180-1913-11eb-8f16-ba036a3f6952.png)



### Testing
I ran `npm run test:notification`. Seems to work as intended.

![image](https://user-images.githubusercontent.com/8883045/97426417-bd8adf00-1913-11eb-89b6-fe349f24b9e7.png)


